### PR TITLE
Moved firmware in example dts to zynq subfolder.

### DIFF
--- a/HW/VivadoProjects/microzed/microzed_jd2cb/dts/microzed_jd2cb_overlay.dts
+++ b/HW/VivadoProjects/microzed/microzed_jd2cb/dts/microzed_jd2cb_overlay.dts
@@ -9,7 +9,7 @@
       #address-cells = <1>;
       #size-cells = <1>;
 
-	  firmware-name = "soc_system_wrapper.bit.bin";
+	  firmware-name = "zynq/microzed_jd2cb.bit.bin";
 
 	  hm2reg_io_0: hm2-socfpga@0x43C00000 {
 		compatible = "machkt,hm2reg-io-1.0";


### PR DESCRIPTION
This example aligns the zynq firmware folder with the Altera folders. The firmware will live in /lib/firmware/zynq to mirror /lib/firmware/socfpga.