### PR TITLE
Add missing source file

### DIFF
--- a/HW/hm2/hm2_socfpga.qip
+++ b/HW/hm2/hm2_socfpga.qip
@@ -10,6 +10,7 @@ set_global_assignment -name SEARCH_PATH ..\\..\\hm2
 set_global_assignment -name VHDL_FILE ../../cv-megawizard/lpm_pack.vhd
 set_global_assignment -name QIP_FILE "../../cv-megawizard/lpm-ip/lpm_mux16.qip"
 set_global_assignment -name QIP_FILE "../../cv-megawizard/lpm-ip/lpm_shiftreg16.qip"
+set_global_assignment -name VHDL_FILE ../../cv-megawizard/SRL16E.vhd
 
 # HM2 VHDL Setup and config probe functions:
 set_global_assignment -name QIP_FILE ../../hm2/functions/hm2_functions.qip


### PR DESCRIPTION
hm2_socfpga.qip was missing a reference to the cv-megawizard/SRL16E.vhd
source file.  Builds were still successful, due to the cv-megawizard
directory being in the IP path, but the missing reference caused a
compile-time warning.

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>