### PR TITLE
Fix qip file

### DIFF
--- a/HW/hm2/hm2_socfpga.qip
+++ b/HW/hm2/hm2_socfpga.qip
@@ -13,7 +13,7 @@ set_global_assignment -name QIP_FILE "../../cv-megawizard/lpm-ip/lpm_shiftreg16.
 set_global_assignment -name VHDL_FILE ../../cv-megawizard/SRL16E.vhd
 
 # Default PIN configuration
-set_global_assignment -name VHDL_FILE ../../hm2/config/PIN_G540x2_34.vhd
+set_global_assignment -name VHDL_FILE ../../hm2/config/PIN_G540x2_34_irq.vhd
 
 # HM2 VHDL Setup and config probe functions:
 set_global_assignment -name QIP_FILE ../../hm2/functions/hm2_functions.qip


### PR DESCRIPTION
Update hm2_socfpga.qip to match change made to hostmot2.vhd:
Default configuration is now PIN_G540x2_34_irq, which needs to be
included via the qip file.

Signed-off-by: Charles Steinkuehler <charles@steinkuehler.net>