### PR TITLE
fixup firmware path in dts, add Makefile to regenerate dtbo's

### DIFF
--- a/SW/MK/dts-overlays/Makefile
+++ b/SW/MK/dts-overlays/Makefile
@@ -1,0 +1,16 @@
+# compile all .dts files into .dtbo (device tree overlays)
+#
+# use dtc which came with kernel:
+DTC=/usr/src/linux-headers-$(shell uname -r)/scripts/dtc/dtc
+DTBS := $(wildcard *.dts)
+DTBO := $(patsubst  %.dts, %.dtbo, $(wildcard *.dts))
+
+%.dtbo: %.dts
+	$(DTC) -I dts -O dtb -@  -o $@ $<
+
+all: $(DTBO)
+
+clean:
+	rm -f $(DTBO)
+
+

--- a/SW/MK/dts-overlays/Makefile
+++ b/SW/MK/dts-overlays/Makefile
@@ -1,7 +1,7 @@
 # compile all .dts files into .dtbo (device tree overlays)
 #
 # use dtc which came with kernel:
-DTC=/usr/src/linux-headers-$(shell uname -r)/scripts/dtc/dtc
+DTC  := /usr/src/linux-headers-$(shell uname -r)/scripts/dtc/dtc
 DTBS := $(wildcard *.dts)
 DTBO := $(patsubst  %.dts, %.dtbo, $(wildcard *.dts))
 

--- a/SW/MK/dts-overlays/hm2reg_uio-irq.dts
+++ b/SW/MK/dts-overlays/hm2reg_uio-irq.dts
@@ -10,7 +10,7 @@
 			#size-cells = <1>;
 
 			ranges = <0x00040000 0xff240000 0x00010000>;
-			firmware-name = "socfpga/socfpga.rbf";
+			firmware-name = "socfpga/DE0_NANO.rbf";
 
 			hm2reg_io_0: hm2-socfpg0@0x40000 {
 				compatible = "hm2reg_io,generic-uio,ui_pdrv";


### PR DESCRIPTION
this is needed for packaging - both the dts files and the Makefile will land in /lib/firmware/socfpga

once it is in the socfpga-package the Makefile can be executed during omap-image-builder chroot after all packages are installed... and then we'll again have a working image using 4.1