### PR TITLE
dtb/template.dts: update for https://github.com/altera-opensource/lin…

### DIFF
--- a/SW/MK/dts-overlays/template.dts
+++ b/SW/MK/dts-overlays/template.dts
@@ -1,27 +1,30 @@
 /dts-v1/; /plugin/;
 
 / {
-	fragment@0 {
-		target-path = "/soc/base_fpga_region";
-		#address-cells = <1>;
-		#size-cells = <1>;
-		__overlay__ {
-			#address-cells = <1>;
-			#size-cells = <1>;
+        fragment@0 {
+                target-path = "/soc/base-fpga-region";
+                #address-cells = <1>;
+                #size-cells = <1>;
+                __overlay__ {
 
-			ranges = <0x00040000 0xff240000 0x00010000>;
-			firmware-name = "%FIRMWARE%";
+                        firmware-name = "%FIRMWARE%";
 
-			hm2reg_io_0: hm2-socfpg0@0x40000 {
-				compatible = "hm2reg_io,generic-uio,ui_pdrv";
-				reg = <0x40000 0x10000>;
-				interrupt-parent = <0x2>;
-				interrupts = <0 43 1>;
-				clocks = <&osc1>;
-				address_width = <14>;
-				data_width = <32>;
-			};
-		};
-	};
+                        #address-cells = <1>;
+                        #size-cells = <1>;
+
+                        ranges = <0x00040000 0xff240000 0x00010000>;
+                        fpga-bridges = <&fpga_bridge0>, <&fpga_bridge1>;
+
+                        hm2reg_io_0: hm2-socfpg0@0x40000 {
+                                compatible = "hm2reg_io,generic-uio,ui_pdrv";
+                                reg = <0x40000 0x10000>;
+                                interrupt-parent = <0x2>;
+                                interrupts = <0 43 1>;
+                                clocks = <&osc1>;
+                                address_width = <14>;
+                                data_width = <32>;
+                        };
+                };
+        };
 };
 


### PR DESCRIPTION
…ux-socfpga/tree/socfpga-4.1.22-ltsi-rt

upstream kernel changes to the dts:
1cf0423 cleaned up the naming
98ba3ec suggests moving 'ranges = ' and 'fpga-bridges =' to the overlay

the updated kernel base supersedes the 'local' change we made in https://github.com/mhaberler/linux-socfpga/commit/4d78db0d316c7b00e45cdf7677a3441f751e3100 and unfortunately this change is NOT backward compatible to the 4.1.17-ltsi-rt kernel - both socfpga-rbf and linux-image-socfpga-rt must be updated in one go!