### PR TITLE
irq logic: trigger on rising edge

### DIFF
--- a/HW/hm2/irqlogic.vhd
+++ b/HW/hm2/irqlogic.vhd
@@ -110,14 +110,14 @@ begin
 				divlatch <= ibus(dividerwidth-1 downto 0);
 				irqdiv <= ibus(dividerwidth-1 downto 0);
 			end if;	
-			if rated = "10" then					-- falling edge of rate source
+			if rated = "01" then					-- rising edge of rate source
 				if irqdivmsb = '1' then			-- note special case where divider latch MSB is set = divide by 1 
 					irqdiv <= divlatch;
 					irqff <= '1';
 				else
 					irqdiv <= irqdiv -1;
 				end if;
-			end if; -- rate falling edge
+			end if; -- rate rising edge
 			if clear = '1' then
 				irqff <= '0';
 			end if;		

--- a/HW/hm2/irqlogics.vhd
+++ b/HW/hm2/irqlogics.vhd
@@ -100,9 +100,9 @@ begin
 			if loadstatus = '1' then 
 				statusreg <= ibus(4 downto 0);
 			end if;	
-			if rated = "10" then					-- falling edge of rate source
+			if rated = "01" then					-- rising edge of rate source
 				irqff <= '1';
-			end if; -- rate falling edge
+			end if; -- rate rising edge
 			if clear = '1' then
 				irqff <= '0';
 			end if;		


### PR DESCRIPTION
as suggested by PCW, see also: https://github.com/machinekit/machinekit/issues/687#issuecomment-239108576

It is strange that you have a large constant offset  (~450 usec)
But now that I look at it, I think thats a bug in the irqlogic vs DPLL
not agreeing on which edge to trigger on

Since many modules use the DPLL outputs, (and trigger on rising edge of ref and timers) I would change the irq logic to agree with the DPLL

	PeriodicIRQlogic : process (clk,statusreg,irqff,readstatus,ratesource)
	begin
		if rising_edge(clk) then
			rated  <= rated(0) & rate;
			if loadstatus = '1' then
				statusreg <= ibus(4 downto 0);
			end if;
--			if rated = "10" then ++			if rated = "01" then
				irqff <= '1';
--			end if; -- rate falling edge
++			end if; -- rate rising edge
rising