### PR TITLE
cv: use same 'compatible' property like zynq

### DIFF
--- a/SW/MK/dts-overlays/template.dts
+++ b/SW/MK/dts-overlays/template.dts
@@ -16,7 +16,7 @@
                         fpga-bridges = <&fpga_bridge0>, <&fpga_bridge1>;
 
                         hm2reg_io_0: hm2-socfpg0@0x40000 {
-                                compatible = "hm2reg_io,generic-uio,ui_pdrv";
+                                compatible = "generic-uio,ui_pdrv";
                                 reg = <0x40000 0x10000>;
                                 interrupt-parent = <0x2>;
                                 interrupts = <0 43 1>;


### PR DESCRIPTION
no reason to retain the hm2reg_io thing