### PR TITLE
dts-overlay/template.dts: bring naming in line with zynq

### DIFF
--- a/SW/MK/dts-overlays/template.dts
+++ b/SW/MK/dts-overlays/template.dts
@@ -15,7 +15,7 @@
                         ranges = <0x00040000 0xff240000 0x00010000>;
                         fpga-bridges = <&fpga_bridge0>, <&fpga_bridge1>;
 
-                        hm2reg_io_0: hm2-socfpg0@0x40000 {
+                        hm2reg_io_0: hm2-socfpga0@0x40000 {
                                 compatible = "generic-uio,ui_pdrv";
                                 reg = <0x40000 0x10000>;
                                 interrupt-parent = <0x2>;


### PR DESCRIPTION
this name needs to be given as instance name for hm2_soc_ol:

newinst hm2_soc_ol hm2-socfpga0 config=...