### PR TITLE
Zynq dts file update, and processor name normalization

### DIFF
--- a/HW/VivadoProjects/make_bitfile.sh
+++ b/HW/VivadoProjects/make_bitfile.sh
@@ -48,6 +48,7 @@ sed -e "s|%PIN_NAME%|$PIN_NAME|" \
     "$IP_DIR"/src/hostmot2_ip_wrap.vhd
 
 PRJ_FILE="$PRJ_DIR_CREATED"/"$PRJ_NAME".tcl
+BIT_FILE="$PRJ_NAME".bit
 
 # Update the project creation script from the config
 sed -e "s|%PRJ_NAME%|$PRJ_NAME|" \
@@ -59,11 +60,23 @@ sed -e "s|%PRJ_NAME%|$PRJ_NAME|" \
     "$PRJ_DIR"/"$TCL_TEMP_FILE" > \
     "$PRJ_FILE"
 
+# Create a dts variant for every input template file a project exposes
+if [ -d "$PRJ_DIR"/dts ]; then
+    temps=`find "$PRJ_DIR"/dts/ -type f -name *.dts.in`
+    for temp in $temps
+    do
+        outname=`basename "$temp"`
+        outfpath="$PRJ_DIR_CREATED"/${outname%_ol.dts.in}_"$FPGA_DEV_SHORT"_ol.dts
+        echo $outfpath
+        sed "s|%BIT_FILE%|$BIT_FILE.bin|" \
+            "$temp" > "$outfpath"
+    done
+fi
+
 # Create the firmware_id.mif file
 cd ../firmware-tag
 make py-proto
 python genfwid.py "$FWID_NAME" > "$PRJ_DIR_CREATED/firmware_id.mif"
-
 cd ../VivadoProjects
 
 # Run the tcl script to build the project and generate the bitfile

--- a/HW/VivadoProjects/microzed/microzed_jd2cb/7z010_config
+++ b/HW/VivadoProjects/microzed/microzed_jd2cb/7z010_config
@@ -5,20 +5,18 @@
 # correct for the project
 TCL_TEMP_FILE=../../zynq_bp.tcl.in
 
-# Base Project Name
-PRJ_NAME=microzed_jd2cb_z7020_bp
-
 # The fpga device we are building for
-FPGA_DEVICE=xc7z020clg400-1
+FPGA_DEVICE=xc7z010clg400-1
+FPGA_DEV_SHORT=7z010
+
+# Base Project Name
+PRJ_NAME=microzed_jd2cb_"$FPGA_DEV_SHORT"
 
 # The board part file url, if the target has one
-BOARD_PART="em.avnet.com:microzed_7020:part0:1.1"
+BOARD_PART="em.avnet.com:microzed_7010:part0:1.1"
 
 # The physical package pin constraint file
 PIN_HW_XDC_FILE=const/microzed_jd2cb_pinmap.xdc
-
-# The name of the bitfile
-BIT_FILE=microzed_jd2cb_z020.bit
 
 # The filename of the top level block diagram
 TOP_LEVEL_BD_FILE=scripts/mzed_jd2cb_bd.tcl

--- a/HW/VivadoProjects/microzed/microzed_jd2cb/7z020_config
+++ b/HW/VivadoProjects/microzed/microzed_jd2cb/7z020_config
@@ -1,35 +1,35 @@
 #!/bin/sh
 
-# TCL Template Filename
+# TCL Template Filename. Leave this here
+# to let the config decide if the base template is
+# correct for the project
 TCL_TEMP_FILE=../../zynq_bp.tcl.in
 
-# Base Project Name
-PRJ_NAME=zturn_jd2cb_z7010_bp
-
 # The fpga device we are building for
-FPGA_DEVICE=xc7z010clg400-1
+FPGA_DEVICE=xc7z020clg400-1
+FPGA_DEV_SHORT=7z020
+
+# Base Project Name
+PRJ_NAME=microzed_jd2cb_"$FPGA_DEV_SHORT"
 
 # The board part file url, if the target has one
-BOARD_PART=""
+BOARD_PART="em.avnet.com:microzed_7020:part0:1.1"
 
 # The physical package pin constraint file
-PIN_HW_XDC_FILE=const/zturn_jd2cb_pinmap.xdc
-
-# The name of the bitfile
-BIT_FILE=zturn_jd2cb_z7010.bit
+PIN_HW_XDC_FILE=const/microzed_jd2cb_pinmap.xdc
 
 # The filename of the top level block diagram
-TOP_LEVEL_BD_FILE=scripts/zturn_jd2cb_bd.tcl
+TOP_LEVEL_BD_FILE=scripts/mzed_jd2cb_bd.tcl
 
 ## HostMot2 Pin constraints - these update the IP. Physical pin constraints
 #  belong in an xdc file above
 
 # HM2 Pin Filename relative to project folder
-PIN_FILE=const/PIN_ZJD2CB_36.vhd
+PIN_FILE=const/PIN_MJD2CB_32.vhd
 # Pin package name defined in above pin file
-PIN_NAME=PIN_ZJD2CB_36
+PIN_NAME=PIN_MJD2CB_32
 #FWID File name in the const folder
-FWID_NAME=FWID_ZJD2CB_36
+FWID_NAME=FWID_MJD2CB_32
 
 ############################################################################
 # HostMot2 Generic Parameters, autofills IP correctly without regenerating
@@ -38,4 +38,4 @@ FWID_NAME=FWID_ZJD2CB_36
 
 # The name of the board to compile into the IP. Matches board name in hal files
 BOARD_NAME_HIGH_HEX=4243444A     #JDCB
-BOARD_NAME_LOW_HEX=4332444A      #JD2Z
+BOARD_NAME_LOW_HEX=4332444A      #JD2M

--- a/HW/VivadoProjects/microzed/microzed_jd2cb/dts/microzed_jd2cb_ol.dts.in
+++ b/HW/VivadoProjects/microzed/microzed_jd2cb/dts/microzed_jd2cb_ol.dts.in
@@ -9,7 +9,7 @@
       #address-cells = <1>;
       #size-cells = <1>;
 
-	  firmware-name = "zynq/microzed_jd2cb.bit.bin";
+	  firmware-name = "zynq/%BIT_FILE%";
 
 	  hm2reg_io_0: hm2-socfpga0@0x43C00000 {
 		compatible = "generic-uio,ui_pdrv";
@@ -17,15 +17,15 @@
 		interrupt-parent = <&intc>;
 		interrupts = <0 29 1>;
 	  };
-	  
-  	  btint_axi_0: btint_axi0@0x43C10000 {
+
+	  btint_axi_0: btint_axi0@0x43C10000 {
 		compatible = "generic-uio,ui_pdrv";
 		reg = < 0x43C10000 0x00010000 >;
 		interrupt-parent = <&intc>;
 		interrupts = <0 30 1>;
 	  };
 
-  	  btint_axi_1: btint_axi1@0x43C20000 {
+	  btint_axi_1: btint_axi1@0x43C20000 {
 		compatible = "generic-uio,ui_pdrv";
 		reg = < 0x43C20000 0x00010000 >;
 		interrupt-parent = <&intc>;
@@ -34,4 +34,3 @@
     };
   };
 };
-

--- a/HW/VivadoProjects/zturn/zturn_jd2cb/7z010_config
+++ b/HW/VivadoProjects/zturn/zturn_jd2cb/7z010_config
@@ -1,32 +1,35 @@
 #!/bin/sh
 
-# TCL Template Filename
+# TCL Template Filename. Leave this here
+# to let the config decide if the base template is
+# correct for the project
 TCL_TEMP_FILE=../../zynq_bp.tcl.in
-
-# Base Project Name
-PRJ_NAME=zturn_ztio_z7010_bp
 
 # The fpga device we are building for
 FPGA_DEVICE=xc7z010clg400-1
+FPGA_DEV_SHORT=7z010
+
+# Base Project Name
+PRJ_NAME=zturn_jd2cb_"$FPGA_DEV_SHORT"
+
+# The board part file url, if the target has one
+BOARD_PART=""
 
 # The physical package pin constraint file
-PIN_HW_XDC_FILE=const/zturn_ztio_pinmap.xdc
-
-# The name of the bitfile
-BIT_FILE=zturn_ztio_z7010.bit
+PIN_HW_XDC_FILE=const/zturn_jd2cb_pinmap.xdc
 
 # The filename of the top level block diagram
-TOP_LEVEL_BD_FILE=scripts/zturn_ztio_bd.tcl
+TOP_LEVEL_BD_FILE=scripts/zturn_jd2cb_bd.tcl
 
 ## HostMot2 Pin constraints - these update the IP. Physical pin constraints
 #  belong in an xdc file above
 
 # HM2 Pin Filename relative to project folder
-PIN_FILE=const/PIN_ZTIO_34.vhd
+PIN_FILE=const/PIN_ZJD2CB_36.vhd
 # Pin package name defined in above pin file
-PIN_NAME=PIN_ZTIO_34
+PIN_NAME=PIN_ZJD2CB_36
 #FWID File name in the const folder
-FWID_NAME=FWID_ZTIO_34
+FWID_NAME=FWID_ZJD2CB_36
 
 ############################################################################
 # HostMot2 Generic Parameters, autofills IP correctly without regenerating
@@ -34,5 +37,5 @@ FWID_NAME=FWID_ZTIO_34
 ############################################################################
 
 # The name of the board to compile into the IP. Matches board name in hal files
-BOARD_NAME_HIGH_HEX=4F49545A    #ZTIO
-BOARD_NAME_LOW_HEX=5249594D     #MYIR
+BOARD_NAME_HIGH_HEX=4243444A     #JDCB
+BOARD_NAME_LOW_HEX=4332444A      #JD2Z

--- a/HW/VivadoProjects/zturn/zturn_jd2cb/7z020_config
+++ b/HW/VivadoProjects/zturn/zturn_jd2cb/7z020_config
@@ -1,22 +1,22 @@
 #!/bin/sh
 
-# TCL Template Filename
+# TCL Template Filename. Leave this here
+# to let the config decide if the base template is
+# correct for the project
 TCL_TEMP_FILE=../../zynq_bp.tcl.in
-
-# Base Project Name
-PRJ_NAME=zturn_jd2cb_z7020_bp
 
 # The fpga device we are building for
 FPGA_DEVICE=xc7z020clg400-1
+FPGA_DEV_SHORT=7z020
+
+# Base Project Name
+PRJ_NAME=zturn_jd2cb_"$FPGA_DEV_SHORT"
 
 # The board part file url, if the target has one
 BOARD_PART=""
 
 # The physical package pin constraint file
 PIN_HW_XDC_FILE=const/zturn_jd2cb_pinmap.xdc
-
-# The name of the bitfile
-BIT_FILE=zturn_jd2cb_z7020.bit
 
 # The filename of the top level block diagram
 TOP_LEVEL_BD_FILE=scripts/zturn_jd2cb_bd.tcl

--- a/HW/VivadoProjects/zturn/zturn_jd2cb/dts/zturn_jd2cb_ol.dts.in
+++ b/HW/VivadoProjects/zturn/zturn_jd2cb/dts/zturn_jd2cb_ol.dts.in
@@ -9,7 +9,7 @@
       #address-cells = <1>;
       #size-cells = <1>;
 
-	  firmware-name = "zynq/zturn_jd2cb.bit.bin";
+	  firmware-name = "zynq/%BIT_FILE%";
 
 	  hm2reg_io_0: hm2-socfpga0@0x43C00000 {
 		compatible = "generic-uio,ui_pdrv";
@@ -17,15 +17,15 @@
 		interrupt-parent = <&intc>;
 		interrupts = <0 29 1>;
 	  };
-	  
-  	  btint_axi_0: btint_axi0@0x43C10000 {
+
+	  btint_axi_0: btint_axi0@0x43C10000 {
 		compatible = "generic-uio,ui_pdrv";
 		reg = < 0x43C10000 0x00010000 >;
 		interrupt-parent = <&intc>;
 		interrupts = <0 30 1>;
 	  };
 
-  	  btint_axi_1: btint_axi1@0x43C20000 {
+	  btint_axi_1: btint_axi1@0x43C20000 {
 		compatible = "generic-uio,ui_pdrv";
 		reg = < 0x43C20000 0x00010000 >;
 		interrupt-parent = <&intc>;
@@ -34,4 +34,3 @@
     };
   };
 };
-

--- a/HW/VivadoProjects/zturn/zturn_ztio/7z010_config
+++ b/HW/VivadoProjects/zturn/zturn_ztio/7z010_config
@@ -3,17 +3,18 @@
 # TCL Template Filename
 TCL_TEMP_FILE=../../zynq_bp.tcl.in
 
-# Base Project Name
-PRJ_NAME=zturn_ztio_z7020_bp
-
 # The fpga device we are building for
-FPGA_DEVICE=xc7z020clg400-1
+FPGA_DEVICE=xc7z010clg400-1
+FPGA_DEV_SHORT=7z010
+
+# Base Project Name
+PRJ_NAME=zturn_ztio_"$FPGA_DEV_SHORT"
+
+# The board part file url, if the target has one
+BOARD_PART=""
 
 # The physical package pin constraint file
 PIN_HW_XDC_FILE=const/zturn_ztio_pinmap.xdc
-
-# The name of the bitfile
-BIT_FILE=zturn_ztio_z7020.bit
 
 # The filename of the top level block diagram
 TOP_LEVEL_BD_FILE=scripts/zturn_ztio_bd.tcl

--- a/HW/VivadoProjects/zturn/zturn_ztio/7z020_config
+++ b/HW/VivadoProjects/zturn/zturn_ztio/7z020_config
@@ -1,37 +1,33 @@
 #!/bin/sh
 
-# TCL Template Filename. Leave this here
-# to let the config decide if the base template is
-# correct for the project
+# TCL Template Filename
 TCL_TEMP_FILE=../../zynq_bp.tcl.in
 
-# Base Project Name
-PRJ_NAME=microzed_jd2cb_z7010_bp
-
 # The fpga device we are building for
-FPGA_DEVICE=xc7z010clg400-1
+FPGA_DEVICE=xc7z020clg400-1
+FPGA_DEV_SHORT=7z020
+
+# Base Project Name
+PRJ_NAME=zturn_ztio_"$FPGA_DEV_SHORT"
 
 # The board part file url, if the target has one
-BOARD_PART="em.avnet.com:microzed_7010:part0:1.1"
+BOARD_PART=""
 
 # The physical package pin constraint file
-PIN_HW_XDC_FILE=const/microzed_jd2cb_pinmap.xdc
-
-# The name of the bitfile
-BIT_FILE=microzed_jd2cb_z010.bit
+PIN_HW_XDC_FILE=const/zturn_ztio_pinmap.xdc
 
 # The filename of the top level block diagram
-TOP_LEVEL_BD_FILE=scripts/mzed_jd2cb_bd.tcl
+TOP_LEVEL_BD_FILE=scripts/zturn_ztio_bd.tcl
 
 ## HostMot2 Pin constraints - these update the IP. Physical pin constraints
 #  belong in an xdc file above
 
 # HM2 Pin Filename relative to project folder
-PIN_FILE=const/PIN_MJD2CB_32.vhd
+PIN_FILE=const/PIN_ZTIO_34.vhd
 # Pin package name defined in above pin file
-PIN_NAME=PIN_MJD2CB_32
+PIN_NAME=PIN_ZTIO_34
 #FWID File name in the const folder
-FWID_NAME=FWID_MJD2CB_32
+FWID_NAME=FWID_ZTIO_34
 
 ############################################################################
 # HostMot2 Generic Parameters, autofills IP correctly without regenerating
@@ -39,5 +35,5 @@ FWID_NAME=FWID_MJD2CB_32
 ############################################################################
 
 # The name of the board to compile into the IP. Matches board name in hal files
-BOARD_NAME_HIGH_HEX=4243444A     #JDCB
-BOARD_NAME_LOW_HEX=4332444A      #JD2M
+BOARD_NAME_HIGH_HEX=4F49545A    #ZTIO
+BOARD_NAME_LOW_HEX=5249594D     #MYIR

--- a/HW/VivadoProjects/zturn/zturn_ztio/dts/zturn_ztio_ol.dts.in
+++ b/HW/VivadoProjects/zturn/zturn_ztio/dts/zturn_ztio_ol.dts.in
@@ -9,7 +9,7 @@
       #address-cells = <1>;
       #size-cells = <1>;
 
-	  firmware-name = "zynq/zturn_ztio.bit.bin";
+	  firmware-name = "zynq/%BIT_FILE%";
 
 	  hm2reg_io_0: hm2-socfpga0@0x43C00000 {
 		compatible = "generic-uio,ui_pdrv";
@@ -20,4 +20,3 @@
     };
   };
 };
-


### PR DESCRIPTION
This fixes dts generation based off processor selection. I also changed the processor naming format to match the Xilinx tech documents instead of their marketing format. Build artifacts are named according to `som_carrier_device.*`.