### PR TITLE
 Update addresses of qsys cores to be consistent across quartus projects 

### DIFF
--- a/HW/QuartusProjects/DE0_Nano_SoC_Cramps/soc_system.qsys
+++ b/HW/QuartusProjects/DE0_Nano_SoC_Cramps/soc_system.qsys
@@ -13,7 +13,7 @@
    {
       datum _sortIndex
       {
-         value = "9";
+         value = "10";
          type = "int";
       }
    }
@@ -26,7 +26,7 @@
       }
       datum baseAddress
       {
-         value = "20672";
+         value = "20480";
          type = "String";
       }
    }
@@ -42,7 +42,7 @@
    {
       datum _sortIndex
       {
-         value = "8";
+         value = "9";
          type = "int";
       }
    }
@@ -124,7 +124,7 @@
    {
       datum _sortIndex
       {
-         value = "11";
+         value = "5";
          type = "int";
       }
    }
@@ -142,7 +142,7 @@
       }
       datum baseAddress
       {
-         value = "196608";
+         value = "3840";
          type = "String";
       }
    }
@@ -150,7 +150,7 @@
    {
       datum _sortIndex
       {
-         value = "6";
+         value = "7";
          type = "int";
       }
    }
@@ -171,7 +171,7 @@
    {
       datum _sortIndex
       {
-         value = "7";
+         value = "8";
          type = "int";
       }
    }
@@ -184,7 +184,7 @@
       }
       datum baseAddress
       {
-         value = "12352";
+         value = "12288";
          type = "String";
       }
    }
@@ -208,7 +208,7 @@
    {
       datum _sortIndex
       {
-         value = "10";
+         value = "11";
          type = "int";
       }
    }
@@ -365,7 +365,7 @@
    {
       datum _sortIndex
       {
-         value = "5";
+         value = "6";
          type = "int";
       }
    }
@@ -1173,7 +1173,7 @@
    start="mm_bridge_0.m0"
    end="button_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x50c0" />
+  <parameter name="baseAddress" value="0x5000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1187,7 +1187,7 @@
  </connection>
  <connection kind="avalon" version="15.1" start="mm_bridge_0.m0" end="led_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x3040" />
+  <parameter name="baseAddress" value="0x3000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1223,7 +1223,7 @@
    start="fpga_only_master.master"
    end="intr_capturer_0.avalon_slave_0">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00030000" />
+  <parameter name="baseAddress" value="0x0f00" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1250,7 +1250,7 @@
    start="fpga_only_master.master"
    end="led_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x3040" />
+  <parameter name="baseAddress" value="0x3000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1268,7 +1268,7 @@
    start="fpga_only_master.master"
    end="button_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x50c0" />
+  <parameter name="baseAddress" value="0x5000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection

--- a/HW/QuartusProjects/DE0_Nano_SoC_Cramps/soc_system.qsys
+++ b/HW/QuartusProjects/DE0_Nano_SoC_Cramps/soc_system.qsys
@@ -13,7 +13,7 @@
    {
       datum _sortIndex
       {
-         value = "3";
+         value = "9";
          type = "int";
       }
    }
@@ -26,7 +26,7 @@
       }
       datum baseAddress
       {
-         value = "65728";
+         value = "20672";
          type = "String";
       }
    }
@@ -34,7 +34,7 @@
    {
       datum _sortIndex
       {
-         value = "10";
+         value = "0";
          type = "int";
       }
    }
@@ -42,7 +42,7 @@
    {
       datum _sortIndex
       {
-         value = "4";
+         value = "8";
          type = "int";
       }
    }
@@ -63,7 +63,7 @@
       }
       datum baseAddress
       {
-         value = "65664";
+         value = "16512";
          type = "String";
       }
    }
@@ -71,7 +71,7 @@
    {
       datum _sortIndex
       {
-         value = "8";
+         value = "3";
          type = "int";
       }
    }
@@ -79,12 +79,17 @@
    {
       datum _sortIndex
       {
-         value = "11";
+         value = "12";
          type = "int";
       }
    }
    element hm2reg_io_0.slave
    {
+      datum _lockedAddress
+      {
+         value = "1";
+         type = "boolean";
+      }
       datum baseAddress
       {
          value = "262144";
@@ -95,7 +100,7 @@
    {
       datum _sortIndex
       {
-         value = "0";
+         value = "1";
          type = "int";
       }
    }
@@ -111,7 +116,7 @@
    {
       datum _sortIndex
       {
-         value = "1";
+         value = "2";
          type = "int";
       }
    }
@@ -119,7 +124,7 @@
    {
       datum _sortIndex
       {
-         value = "9";
+         value = "11";
          type = "int";
       }
    }
@@ -145,7 +150,7 @@
    {
       datum _sortIndex
       {
-         value = "7";
+         value = "6";
          type = "int";
       }
    }
@@ -158,7 +163,7 @@
       }
       datum baseAddress
       {
-         value = "131072";
+         value = "8192";
          type = "String";
       }
    }
@@ -166,7 +171,7 @@
    {
       datum _sortIndex
       {
-         value = "5";
+         value = "7";
          type = "int";
       }
    }
@@ -179,23 +184,44 @@
       }
       datum baseAddress
       {
-         value = "65600";
+         value = "12352";
          type = "String";
+      }
+   }
+   element mm_bridge_0
+   {
+      datum _sortIndex
+      {
+         value = "4";
+         type = "int";
+      }
+   }
+   element mm_bridge_0.s0
+   {
+      datum _lockedAddress
+      {
+         value = "1";
+         type = "boolean";
       }
    }
    element onchip_memory2_0
    {
       datum _sortIndex
       {
-         value = "6";
+         value = "10";
          type = "int";
       }
    }
    element onchip_memory2_0.s1
    {
+      datum _lockedAddress
+      {
+         value = "1";
+         type = "boolean";
+      }
       datum baseAddress
       {
-         value = "0";
+         value = "65536";
          type = "String";
       }
    }
@@ -339,7 +365,7 @@
    {
       datum _sortIndex
       {
-         value = "2";
+         value = "5";
          type = "int";
       }
    }
@@ -352,7 +378,7 @@
       }
       datum baseAddress
       {
-         value = "65536";
+         value = "4096";
          type = "String";
       }
    }
@@ -1058,6 +1084,26 @@
   <parameter name="width" value="8" />
  </module>
  <module
+   name="mm_bridge_0"
+   kind="altera_avalon_mm_bridge"
+   version="15.1"
+   enabled="1">
+  <parameter name="ADDRESS_UNITS" value="SYMBOLS" />
+  <parameter name="ADDRESS_WIDTH" value="10" />
+  <parameter name="AUTO_CLK_CLOCK_RATE" value="50000000" />
+  <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone V" />
+  <parameter name="DATA_WIDTH" value="32" />
+  <parameter name="LINEWRAPBURSTS" value="0" />
+  <parameter name="MAX_BURST_SIZE" value="1" />
+  <parameter name="MAX_PENDING_RESPONSES" value="4" />
+  <parameter name="PIPELINE_COMMAND" value="1" />
+  <parameter name="PIPELINE_RESPONSE" value="1" />
+  <parameter name="SYMBOL_WIDTH" value="8" />
+  <parameter name="SYSINFO_ADDR_WIDTH" value="19" />
+  <parameter name="USE_AUTO_ADDRESS_WIDTH" value="1" />
+  <parameter name="USE_RESPONSE" value="0" />
+ </module>
+ <module
    name="onchip_memory2_0"
    kind="altera_avalon_onchip_memory2"
    version="15.1"
@@ -1097,8 +1143,8 @@
  <connection
    kind="avalon"
    version="15.1"
-   start="hps_0.h2f_axi_master"
-   end="onchip_memory2_0.s1">
+   start="hps_0.h2f_lw_axi_master"
+   end="mm_bridge_0.s0">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x0000" />
   <parameter name="defaultConnection" value="false" />
@@ -1106,17 +1152,49 @@
  <connection
    kind="avalon"
    version="15.1"
-   start="hps_0.h2f_lw_axi_master"
+   start="mm_bridge_0.m0"
    end="jtag_uart.avalon_jtag_slave">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00020000" />
+  <parameter name="baseAddress" value="0x2000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
    kind="avalon"
    version="15.1"
-   start="hps_0.h2f_lw_axi_master"
+   start="mm_bridge_0.m0"
    end="sysid_qsys.control_slave">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x1000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="15.1"
+   start="mm_bridge_0.m0"
+   end="button_pio.s1">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x50c0" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="15.1"
+   start="mm_bridge_0.m0"
+   end="dipsw_pio.s1">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x4080" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection kind="avalon" version="15.1" start="mm_bridge_0.m0" end="led_pio.s1">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x3040" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="15.1"
+   start="mm_bridge_0.m0"
+   end="onchip_memory2_0.s1">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x00010000" />
   <parameter name="defaultConnection" value="false" />
@@ -1124,34 +1202,7 @@
  <connection
    kind="avalon"
    version="15.1"
-   start="hps_0.h2f_lw_axi_master"
-   end="button_pio.s1">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x000100c0" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="15.1"
-   start="hps_0.h2f_lw_axi_master"
-   end="dipsw_pio.s1">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00010080" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="15.1"
-   start="hps_0.h2f_lw_axi_master"
-   end="led_pio.s1">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00010040" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="15.1"
-   start="hps_0.h2f_lw_axi_master"
+   start="mm_bridge_0.m0"
    end="hm2reg_io_0.slave">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x00040000" />
@@ -1163,7 +1214,7 @@
    start="fpga_only_master.master"
    end="jtag_uart.avalon_jtag_slave">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00020000" />
+  <parameter name="baseAddress" value="0x2000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1181,7 +1232,7 @@
    start="fpga_only_master.master"
    end="sysid_qsys.control_slave">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00010000" />
+  <parameter name="baseAddress" value="0x1000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1199,7 +1250,7 @@
    start="fpga_only_master.master"
    end="led_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00010040" />
+  <parameter name="baseAddress" value="0x3040" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1208,7 +1259,7 @@
    start="fpga_only_master.master"
    end="dipsw_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00010080" />
+  <parameter name="baseAddress" value="0x4080" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1217,7 +1268,7 @@
    start="fpga_only_master.master"
    end="button_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x000100c0" />
+  <parameter name="baseAddress" value="0x50c0" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1226,7 +1277,7 @@
    start="fpga_only_master.master"
    end="onchip_memory2_0.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x0000" />
+  <parameter name="baseAddress" value="0x00010000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1253,6 +1304,7 @@
  <connection kind="clock" version="15.1" start="clk_0.clk" end="dipsw_pio.clk" />
  <connection kind="clock" version="15.1" start="clk_0.clk" end="button_pio.clk" />
  <connection kind="clock" version="15.1" start="clk_0.clk" end="jtag_uart.clk" />
+ <connection kind="clock" version="15.1" start="clk_0.clk" end="mm_bridge_0.clk" />
  <connection
    kind="clock"
    version="15.1"
@@ -1291,14 +1343,14 @@
    version="15.1"
    start="hps_0.f2h_irq0"
    end="button_pio.irq">
-  <parameter name="irqNumber" value="1" />
+  <parameter name="irqNumber" value="2" />
  </connection>
  <connection
    kind="interrupt"
    version="15.1"
    start="hps_0.f2h_irq0"
    end="dipsw_pio.irq">
-  <parameter name="irqNumber" value="2" />
+  <parameter name="irqNumber" value="1" />
  </connection>
  <connection
    kind="interrupt"
@@ -1319,14 +1371,14 @@
    version="15.1"
    start="intr_capturer_0.interrupt_receiver"
    end="button_pio.irq">
-  <parameter name="irqNumber" value="1" />
+  <parameter name="irqNumber" value="2" />
  </connection>
  <connection
    kind="interrupt"
    version="15.1"
    start="intr_capturer_0.interrupt_receiver"
    end="dipsw_pio.irq">
-  <parameter name="irqNumber" value="2" />
+  <parameter name="irqNumber" value="1" />
  </connection>
  <connection
    kind="interrupt"
@@ -1375,6 +1427,11 @@
    version="15.1"
    start="clk_0.clk_reset"
    end="hm2reg_io_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="clk_0.clk_reset"
+   end="mm_bridge_0.reset" />
  <connection
    kind="reset"
    version="15.1"
@@ -1403,6 +1460,11 @@
  <connection
    kind="reset"
    version="15.1"
+   start="hps_only_master.master_reset"
+   end="hps_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
    start="fpga_only_master.master_reset"
    end="button_pio.reset" />
  <connection
@@ -1445,6 +1507,31 @@
    version="15.1"
    start="hps_only_master.master_reset"
    end="hm2reg_io_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="button_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="dipsw_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="mm_bridge_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="mm_bridge_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="sysid_qsys.reset" />
  <connection
    kind="reset"
    version="15.1"

--- a/HW/QuartusProjects/DE0_Nano_SoC_DB25/DE0_Nano_SoC_DB25.vhd
+++ b/HW/QuartusProjects/DE0_Nano_SoC_DB25/DE0_Nano_SoC_DB25.vhd
@@ -275,14 +275,7 @@ begin
 --      mk_io_hm2_we                            => hm_chipsel,              --                               .hm2_chipsel
         mk_io_hm2_int_in                        => irq,                     --                               .hm2_int_in
         clk_100mhz_out_clk                      => hm_clk_med,              --                 clk_100mhz_out.clk
-        clk_200mhz_out_clk                      => hm_clk_high,             --                 clk_100mhz_out.clk
-        adc_io_convst                           => ADC_CONVST,              --                            adc.CONVST
-        adc_io_sck                              => ADC_SCK,                 --                               .SCK
-        adc_io_sdi                              => ADC_SDI,                 --                               .SDI
-        adc_io_sdo                              => ADC_SDO                  --                               .SDO
---      axi_str_data                            => out_data[7:0],           --                    stream_port.data
---      axi_str_valid                           => out_data[8],             --                               .valid
---      axi_str_ready                           => ar_in_sig[1])            --                               .ready
+        clk_200mhz_out_clk                      => hm_clk_high              --                 clk_100mhz_out.clk
 );
 
 -- Debounce logic to clean out glitches within 1ms

--- a/HW/QuartusProjects/DE0_Nano_SoC_DB25/soc_system.qsys
+++ b/HW/QuartusProjects/DE0_Nano_SoC_DB25/soc_system.qsys
@@ -13,7 +13,7 @@
    {
       datum _sortIndex
       {
-         value = "9";
+         value = "10";
          type = "int";
       }
    }
@@ -42,7 +42,7 @@
    {
       datum _sortIndex
       {
-         value = "8";
+         value = "9";
          type = "int";
       }
    }
@@ -124,7 +124,7 @@
    {
       datum _sortIndex
       {
-         value = "11";
+         value = "5";
          type = "int";
       }
    }
@@ -142,7 +142,7 @@
       }
       datum baseAddress
       {
-         value = "196608";
+         value = "3840";
          type = "String";
       }
    }
@@ -150,7 +150,7 @@
    {
       datum _sortIndex
       {
-         value = "6";
+         value = "7";
          type = "int";
       }
    }
@@ -171,7 +171,7 @@
    {
       datum _sortIndex
       {
-         value = "7";
+         value = "8";
          type = "int";
       }
    }
@@ -208,7 +208,7 @@
    {
       datum _sortIndex
       {
-         value = "10";
+         value = "11";
          type = "int";
       }
    }
@@ -365,7 +365,7 @@
    {
       datum _sortIndex
       {
-         value = "5";
+         value = "6";
          type = "int";
       }
    }
@@ -1234,7 +1234,7 @@
    start="fpga_only_master.master"
    end="intr_capturer_0.avalon_slave_0">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00030000" />
+  <parameter name="baseAddress" value="0x0f00" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection

--- a/HW/QuartusProjects/DE0_Nano_SoC_DB25/soc_system.qsys
+++ b/HW/QuartusProjects/DE0_Nano_SoC_DB25/soc_system.qsys
@@ -9,27 +9,11 @@
    categories="System" />
  <parameter name="bonusData"><![CDATA[bonusData 
 {
-   element adc_ltc2308_fifo_0
-   {
-      datum _sortIndex
-      {
-         value = "12";
-         type = "int";
-      }
-   }
-   element adc_ltc2308_fifo_0.slave
-   {
-      datum baseAddress
-      {
-         value = "327680";
-         type = "String";
-      }
-   }
    element button_pio
    {
       datum _sortIndex
       {
-         value = "3";
+         value = "9";
          type = "int";
       }
    }
@@ -42,7 +26,7 @@
       }
       datum baseAddress
       {
-         value = "65728";
+         value = "20480";
          type = "String";
       }
    }
@@ -50,7 +34,7 @@
    {
       datum _sortIndex
       {
-         value = "10";
+         value = "0";
          type = "int";
       }
    }
@@ -58,7 +42,7 @@
    {
       datum _sortIndex
       {
-         value = "4";
+         value = "8";
          type = "int";
       }
    }
@@ -79,7 +63,7 @@
       }
       datum baseAddress
       {
-         value = "65664";
+         value = "16512";
          type = "String";
       }
    }
@@ -87,7 +71,7 @@
    {
       datum _sortIndex
       {
-         value = "8";
+         value = "3";
          type = "int";
       }
    }
@@ -95,12 +79,17 @@
    {
       datum _sortIndex
       {
-         value = "11";
+         value = "12";
          type = "int";
       }
    }
    element hm2reg_io_0.slave
    {
+      datum _lockedAddress
+      {
+         value = "1";
+         type = "boolean";
+      }
       datum baseAddress
       {
          value = "262144";
@@ -111,7 +100,7 @@
    {
       datum _sortIndex
       {
-         value = "0";
+         value = "1";
          type = "int";
       }
    }
@@ -127,7 +116,7 @@
    {
       datum _sortIndex
       {
-         value = "1";
+         value = "2";
          type = "int";
       }
    }
@@ -135,7 +124,7 @@
    {
       datum _sortIndex
       {
-         value = "9";
+         value = "11";
          type = "int";
       }
    }
@@ -161,7 +150,7 @@
    {
       datum _sortIndex
       {
-         value = "7";
+         value = "6";
          type = "int";
       }
    }
@@ -174,7 +163,7 @@
       }
       datum baseAddress
       {
-         value = "131072";
+         value = "8192";
          type = "String";
       }
    }
@@ -182,7 +171,7 @@
    {
       datum _sortIndex
       {
-         value = "5";
+         value = "7";
          type = "int";
       }
    }
@@ -195,23 +184,52 @@
       }
       datum baseAddress
       {
-         value = "65600";
+         value = "12288";
          type = "String";
+      }
+   }
+   element mm_bridge_0
+   {
+      datum _sortIndex
+      {
+         value = "4";
+         type = "int";
+      }
+   }
+   element mm_bridge_0.s0
+   {
+      datum _lockedAddress
+      {
+         value = "0";
+         type = "boolean";
       }
    }
    element onchip_memory2_0
    {
       datum _sortIndex
       {
-         value = "6";
+         value = "10";
          type = "int";
       }
    }
    element onchip_memory2_0.s1
    {
+      datum _lockedAddress
+      {
+         value = "1";
+         type = "boolean";
+      }
       datum baseAddress
       {
-         value = "0";
+         value = "65536";
+         type = "String";
+      }
+   }
+   element soc_system
+   {
+      datum _originalDeviceFamily
+      {
+         value = "Cyclone V";
          type = "String";
       }
    }
@@ -347,7 +365,7 @@
    {
       datum _sortIndex
       {
-         value = "2";
+         value = "5";
          type = "int";
       }
    }
@@ -360,7 +378,7 @@
       }
       datum baseAddress
       {
-         value = "65536";
+         value = "4096";
          type = "String";
       }
    }
@@ -378,18 +396,13 @@
  <parameter name="hideFromIPCatalog" value="false" />
  <parameter name="lockedInterfaceDefinition" value="" />
  <parameter name="maxAdditionalLatency" value="1" />
- <parameter name="projectName" value="soc_system.qpf" />
+ <parameter name="projectName">DE0_Nano_SoC_DB25.qpf</parameter>
  <parameter name="sopcBorderPoints" value="false" />
  <parameter name="systemHash" value="0" />
  <parameter name="testBenchDutName" value="" />
  <parameter name="timeStamp" value="0" />
  <parameter name="useTestBenchNamingPattern" value="false" />
  <instanceScript></instanceScript>
- <interface
-   name="adc_io"
-   internal="adc_ltc2308_fifo_0.conduit_end"
-   type="conduit"
-   dir="end" />
  <interface
    name="button_pio"
    internal="button_pio.external_connection"
@@ -445,11 +458,6 @@
  <interface name="memory" internal="hps_0.memory" type="conduit" dir="end" />
  <interface name="mk_io" internal="hm2reg_io_0.pins" type="conduit" dir="end" />
  <interface name="reset" internal="clk_0.clk_in_reset" type="reset" dir="end" />
- <module
-   name="adc_ltc2308_fifo_0"
-   kind="adc_ltc2308_fifo"
-   version="1.1"
-   enabled="1" />
  <module name="button_pio" kind="altera_avalon_pio" version="15.1" enabled="1">
   <parameter name="bitClearingEdgeCapReg" value="true" />
   <parameter name="bitModifyingOutReg" value="false" />
@@ -502,7 +510,6 @@
   <parameter name="ADDRESS_WIDTH" value="14" />
   <parameter name="DATA_WIDTH" value="32" />
   <parameter name="IRQ_EN" value="1" />
-  <parameter name="MODE_0" value="2" />
  </module>
  <module name="hps_0" kind="altera_hps" version="15.1" enabled="1">
   <parameter name="ABSTRACT_REAL_COMPARE_TEST" value="false" />
@@ -1088,6 +1095,26 @@
   <parameter name="width" value="8" />
  </module>
  <module
+   name="mm_bridge_0"
+   kind="altera_avalon_mm_bridge"
+   version="15.1"
+   enabled="1">
+  <parameter name="ADDRESS_UNITS" value="SYMBOLS" />
+  <parameter name="ADDRESS_WIDTH" value="10" />
+  <parameter name="AUTO_CLK_CLOCK_RATE" value="50000000" />
+  <parameter name="AUTO_DEVICE_FAMILY" value="Cyclone V" />
+  <parameter name="DATA_WIDTH" value="32" />
+  <parameter name="LINEWRAPBURSTS" value="0" />
+  <parameter name="MAX_BURST_SIZE" value="1" />
+  <parameter name="MAX_PENDING_RESPONSES" value="4" />
+  <parameter name="PIPELINE_COMMAND" value="1" />
+  <parameter name="PIPELINE_RESPONSE" value="1" />
+  <parameter name="SYMBOL_WIDTH" value="8" />
+  <parameter name="SYSINFO_ADDR_WIDTH" value="19" />
+  <parameter name="USE_AUTO_ADDRESS_WIDTH" value="1" />
+  <parameter name="USE_RESPONSE" value="0" />
+ </module>
+ <module
    name="onchip_memory2_0"
    kind="altera_avalon_onchip_memory2"
    version="15.1"
@@ -1127,8 +1154,8 @@
  <connection
    kind="avalon"
    version="15.1"
-   start="hps_0.h2f_axi_master"
-   end="onchip_memory2_0.s1">
+   start="hps_0.h2f_lw_axi_master"
+   end="mm_bridge_0.s0">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x0000" />
   <parameter name="defaultConnection" value="false" />
@@ -1136,17 +1163,49 @@
  <connection
    kind="avalon"
    version="15.1"
-   start="hps_0.h2f_lw_axi_master"
+   start="mm_bridge_0.m0"
    end="jtag_uart.avalon_jtag_slave">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00020000" />
+  <parameter name="baseAddress" value="0x2000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
    kind="avalon"
    version="15.1"
-   start="hps_0.h2f_lw_axi_master"
+   start="mm_bridge_0.m0"
    end="sysid_qsys.control_slave">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x1000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="15.1"
+   start="mm_bridge_0.m0"
+   end="button_pio.s1">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x5000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="15.1"
+   start="mm_bridge_0.m0"
+   end="dipsw_pio.s1">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x4080" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection kind="avalon" version="15.1" start="mm_bridge_0.m0" end="led_pio.s1">
+  <parameter name="arbitrationPriority" value="1" />
+  <parameter name="baseAddress" value="0x3000" />
+  <parameter name="defaultConnection" value="false" />
+ </connection>
+ <connection
+   kind="avalon"
+   version="15.1"
+   start="mm_bridge_0.m0"
+   end="onchip_memory2_0.s1">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x00010000" />
   <parameter name="defaultConnection" value="false" />
@@ -1154,34 +1213,7 @@
  <connection
    kind="avalon"
    version="15.1"
-   start="hps_0.h2f_lw_axi_master"
-   end="button_pio.s1">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x000100c0" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="15.1"
-   start="hps_0.h2f_lw_axi_master"
-   end="dipsw_pio.s1">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00010080" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="15.1"
-   start="hps_0.h2f_lw_axi_master"
-   end="led_pio.s1">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00010040" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="15.1"
-   start="hps_0.h2f_lw_axi_master"
+   start="mm_bridge_0.m0"
    end="hm2reg_io_0.slave">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x00040000" />
@@ -1190,19 +1222,10 @@
  <connection
    kind="avalon"
    version="15.1"
-   start="hps_0.h2f_lw_axi_master"
-   end="adc_ltc2308_fifo_0.slave">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00050000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="15.1"
    start="fpga_only_master.master"
    end="jtag_uart.avalon_jtag_slave">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00020000" />
+  <parameter name="baseAddress" value="0x2000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1220,7 +1243,7 @@
    start="fpga_only_master.master"
    end="sysid_qsys.control_slave">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00010000" />
+  <parameter name="baseAddress" value="0x1000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1238,7 +1261,7 @@
    start="fpga_only_master.master"
    end="led_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00010040" />
+  <parameter name="baseAddress" value="0x3000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1247,7 +1270,7 @@
    start="fpga_only_master.master"
    end="dipsw_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00010080" />
+  <parameter name="baseAddress" value="0x4080" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1256,7 +1279,7 @@
    start="fpga_only_master.master"
    end="button_pio.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x000100c0" />
+  <parameter name="baseAddress" value="0x5000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1265,7 +1288,7 @@
    start="fpga_only_master.master"
    end="onchip_memory2_0.s1">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x0000" />
+  <parameter name="baseAddress" value="0x00010000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1275,15 +1298,6 @@
    end="hm2reg_io_0.slave">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x00040000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="15.1"
-   start="fpga_only_master.master"
-   end="adc_ltc2308_fifo_0.slave">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00050000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1301,6 +1315,7 @@
  <connection kind="clock" version="15.1" start="clk_0.clk" end="dipsw_pio.clk" />
  <connection kind="clock" version="15.1" start="clk_0.clk" end="button_pio.clk" />
  <connection kind="clock" version="15.1" start="clk_0.clk" end="jtag_uart.clk" />
+ <connection kind="clock" version="15.1" start="clk_0.clk" end="mm_bridge_0.clk" />
  <connection
    kind="clock"
    version="15.1"
@@ -1312,11 +1327,6 @@
    start="clk_0.clk"
    end="intr_capturer_0.clock" />
  <connection kind="clock" version="15.1" start="clk_0.clk" end="hm2reg_io_0.clock" />
- <connection
-   kind="clock"
-   version="15.1"
-   start="clk_0.clk"
-   end="adc_ltc2308_fifo_0.clock_sink" />
  <connection
    kind="clock"
    version="15.1"
@@ -1333,11 +1343,6 @@
    start="clk_0.clk"
    end="hps_0.h2f_lw_axi_clock" />
  <connection
-   kind="clock"
-   version="15.1"
-   start="hps_0.h2f_user1_clock"
-   end="adc_ltc2308_fifo_0.clock_sink_adc" />
- <connection
    kind="interrupt"
    version="15.1"
    start="hps_0.f2h_irq0"
@@ -1349,14 +1354,14 @@
    version="15.1"
    start="hps_0.f2h_irq0"
    end="button_pio.irq">
-  <parameter name="irqNumber" value="1" />
+  <parameter name="irqNumber" value="2" />
  </connection>
  <connection
    kind="interrupt"
    version="15.1"
    start="hps_0.f2h_irq0"
    end="dipsw_pio.irq">
-  <parameter name="irqNumber" value="2" />
+  <parameter name="irqNumber" value="1" />
  </connection>
  <connection
    kind="interrupt"
@@ -1377,14 +1382,14 @@
    version="15.1"
    start="intr_capturer_0.interrupt_receiver"
    end="button_pio.irq">
-  <parameter name="irqNumber" value="1" />
+  <parameter name="irqNumber" value="2" />
  </connection>
  <connection
    kind="interrupt"
    version="15.1"
    start="intr_capturer_0.interrupt_receiver"
    end="dipsw_pio.irq">
-  <parameter name="irqNumber" value="2" />
+  <parameter name="irqNumber" value="1" />
  </connection>
  <connection
    kind="interrupt"
@@ -1437,17 +1442,17 @@
    kind="reset"
    version="15.1"
    start="clk_0.clk_reset"
+   end="mm_bridge_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="clk_0.clk_reset"
    end="onchip_memory2_0.reset1" />
  <connection
    kind="reset"
    version="15.1"
    start="clk_0.clk_reset"
    end="intr_capturer_0.reset_sink" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="clk_0.clk_reset"
-   end="adc_ltc2308_fifo_0.reset_sink" />
  <connection
    kind="reset"
    version="15.1"
@@ -1462,6 +1467,11 @@
    kind="reset"
    version="15.1"
    start="fpga_only_master.master_reset"
+   end="hps_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
    end="hps_only_master.clk_reset" />
  <connection
    kind="reset"
@@ -1511,6 +1521,31 @@
  <connection
    kind="reset"
    version="15.1"
+   start="hps_only_master.master_reset"
+   end="button_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="dipsw_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="sysid_qsys.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="mm_bridge_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="mm_bridge_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
    start="fpga_only_master.master_reset"
    end="onchip_memory2_0.reset1" />
  <connection
@@ -1528,16 +1563,6 @@
    version="15.1"
    start="hps_only_master.master_reset"
    end="intr_capturer_0.reset_sink" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="fpga_only_master.master_reset"
-   end="adc_ltc2308_fifo_0.reset_sink" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_only_master.master_reset"
-   end="adc_ltc2308_fifo_0.reset_sink" />
  <interconnectRequirement for="$system" name="qsys_mm.clockCrossingAdapter" value="HANDSHAKE" />
  <interconnectRequirement for="$system" name="qsys_mm.maxAdditionalLatency" value="1" />
 </system>

--- a/HW/QuartusProjects/DE0_Nano_SoC_DB25/soc_system_pkg.vhd
+++ b/HW/QuartusProjects/DE0_Nano_SoC_DB25/soc_system_pkg.vhd
@@ -5,10 +5,6 @@ package soc_pkg is
 	-- From: soc_system/soc_system.cmp
 	component soc_system is
 		port (
-			adc_io_convst                         : out   std_logic;                                        -- convst
-			adc_io_sck                            : out   std_logic;                                        -- sck
-			adc_io_sdi                            : out   std_logic;                                        -- sdi
-			adc_io_sdo                            : in    std_logic                     := 'X';             -- sdo
 			button_pio_export                     : in    std_logic_vector(3 downto 0)  := (others => 'X'); -- export
 			clk_clk                               : in    std_logic                     := 'X';             -- clk
 			clk_100mhz_out_clk                    : out   std_logic;                                        -- clk

--- a/HW/QuartusProjects/DE10_Nano_FB_Cramps/DE10_Nano_FB_Cramps.sv
+++ b/HW/QuartusProjects/DE10_Nano_FB_Cramps/DE10_Nano_FB_Cramps.sv
@@ -119,7 +119,7 @@ parameter NumIOAddrReg = 6;
     wire        hps_debug_reset;
 //    wire [27:0] stm_hw_events;
     wire 		fpga_clk_50;
-    wire        clk_75;
+    wire        lcd_clk;
 
 // connection of internal logics
 //	assign LED[5:1] = fpga_led_internal | {7'b0000000, led_level};
@@ -166,13 +166,13 @@ I2C_HDMI_Config u_I2C_HDMI_Config (
     .HDMI_TX_INT(HDMI_TX_INT)
     );
 
-    assign HDMI_TX_CLK = clk_75;
+    assign HDMI_TX_CLK = lcd_clk;
 
 soc_system u0 (
     //Clock&Reset
     .clk_clk                                     (FPGA_CLK1_50 ),                               //                            clk.clk
     .reset_reset_n                               (hps_fpga_reset_n ),                         //                          reset.reset_n
-    .alt_vip_itc_0_clocked_video_vid_clk       (clk_75 ),       // alt_vip_itc_0_clocked_video.vid_clk
+    .alt_vip_itc_0_clocked_video_vid_clk       (lcd_clk ),       // alt_vip_itc_0_clocked_video.vid_clk
     .alt_vip_itc_0_clocked_video_vid_data      (HDMI_TX_D ),      //                            .vid_data
     .alt_vip_itc_0_clocked_video_underflow     ( ),     //                            .underflow
     .alt_vip_itc_0_clocked_video_vid_datavalid (HDMI_TX_DE), //                            .vid_datavalid
@@ -181,7 +181,7 @@ soc_system u0 (
     .alt_vip_itc_0_clocked_video_vid_f         ( ),         //                            .vid_f
     .alt_vip_itc_0_clocked_video_vid_h         ( ),         //                            .vid_h
     .alt_vip_itc_0_clocked_video_vid_v         ( ),          //                            .vid_v
-    .lcd_clk_clk                               (clk_75),                               //                        lcd_clk.clk
+    .lcd_clk_clk                               (lcd_clk),                               //                        lcd_clk.clk
     .pll_stream_locked_export                  (),                   //              pll_stream_locked.export
     //HPS ddr3
     .memory_mem_a                          ( HPS_DDR3_ADDR),                       //                memory.mem_a

--- a/HW/QuartusProjects/DE10_Nano_FB_Cramps/soc_system.qsys
+++ b/HW/QuartusProjects/DE10_Nano_FB_Cramps/soc_system.qsys
@@ -13,7 +13,7 @@
    {
       datum _sortIndex
       {
-         value = "10";
+         value = "12";
          type = "int";
       }
    }
@@ -21,12 +21,12 @@
    {
       datum _lockedAddress
       {
-         value = "0";
+         value = "1";
          type = "boolean";
       }
       datum baseAddress
       {
-         value = "327680";
+         value = "196608";
          type = "String";
       }
    }
@@ -34,7 +34,7 @@
    {
       datum _sortIndex
       {
-         value = "12";
+         value = "14";
          type = "int";
       }
    }
@@ -42,7 +42,7 @@
    {
       datum _sortIndex
       {
-         value = "11";
+         value = "13";
          type = "int";
       }
    }
@@ -50,7 +50,7 @@
    {
       datum _lockedAddress
       {
-         value = "0";
+         value = "1";
          type = "boolean";
       }
       datum baseAddress
@@ -63,7 +63,7 @@
    {
       datum _sortIndex
       {
-         value = "7";
+         value = "10";
          type = "int";
       }
       datum sopceditor_expanded
@@ -102,7 +102,7 @@
    {
       datum _sortIndex
       {
-         value = "8";
+         value = "9";
          type = "int";
       }
       datum sopceditor_expanded
@@ -136,7 +136,7 @@
    {
       datum _sortIndex
       {
-         value = "5";
+         value = "4";
          type = "int";
       }
       datum sopceditor_expanded
@@ -155,6 +155,11 @@
    }
    element hm2reg_io_0.slave
    {
+      datum _lockedAddress
+      {
+         value = "1";
+         type = "boolean";
+      }
       datum baseAddress
       {
          value = "262144";
@@ -165,7 +170,7 @@
    {
       datum _sortIndex
       {
-         value = "1";
+         value = "2";
          type = "int";
       }
       datum sopceditor_expanded
@@ -207,15 +212,20 @@
    {
       datum _sortIndex
       {
-         value = "14";
+         value = "11";
          type = "int";
       }
    }
    element intr_capturer_0.avalon_slave_0
    {
+      datum _lockedAddress
+      {
+         value = "1";
+         type = "boolean";
+      }
       datum baseAddress
       {
-         value = "196608";
+         value = "24576";
          type = "String";
       }
    }
@@ -223,7 +233,7 @@
    {
       datum _sortIndex
       {
-         value = "2";
+         value = "7";
          type = "int";
       }
       datum sopceditor_expanded
@@ -249,7 +259,7 @@
    {
       datum _sortIndex
       {
-         value = "9";
+         value = "8";
          type = "int";
       }
       datum sopceditor_expanded
@@ -275,7 +285,7 @@
    {
       datum _sortIndex
       {
-         value = "6";
+         value = "5";
          type = "int";
       }
    }
@@ -287,11 +297,11 @@
          type = "boolean";
       }
    }
-   element pll_stream
+   element pll_lcd
    {
       datum _sortIndex
       {
-         value = "13";
+         value = "1";
          type = "int";
       }
    }
@@ -339,7 +349,7 @@
    {
       datum _sortIndex
       {
-         value = "4";
+         value = "6";
          type = "int";
       }
       datum sopceditor_expanded
@@ -417,13 +427,8 @@
  <interface name="hps_0_f2h_debug_reset_req" internal="hps_0.f2h_debug_reset_req" />
  <interface name="hps_0_f2h_stm_hw_events" internal="hps_0.f2h_stm_hw_events" />
  <interface name="hps_0_f2h_warm_reset_req" internal="hps_0.f2h_warm_reset_req" />
- <interface
-   name="hps_0_h2f_reset"
-   internal="hps_0.h2f_reset"
-   type="reset"
-   dir="start" />
  <interface name="hps_0_hps_io" internal="hps_0.hps_io" type="conduit" dir="end" />
- <interface name="lcd_clk" internal="pll_stream.outclk1" type="clock" dir="start" />
+ <interface name="lcd_clk" internal="pll_lcd.outclk1" type="clock" dir="start" />
  <interface
    name="led_pio_external_connection"
    internal="led_pio.external_connection"
@@ -433,7 +438,7 @@
  <interface name="mk_io" internal="hm2reg_io_0.pins" type="conduit" dir="end" />
  <interface
    name="pll_stream_locked"
-   internal="pll_stream.locked"
+   internal="pll_lcd.locked"
    type="conduit"
    dir="end" />
  <interface name="reset" internal="clk_0.clk_in_reset" type="reset" dir="end" />
@@ -444,7 +449,7 @@
    enabled="1">
   <parameter name="CLOCK_RATE" value="50000000" />
   <parameter name="INTR_TYPE" value="0" />
-  <parameter name="IRQ_PORT_CNT" value="3" />
+  <parameter name="IRQ_PORT_CNT" value="4" />
  </module>
  <module name="alt_vip_itc_0" kind="alt_vip_itc" version="14.0" enabled="1">
   <parameter name="ACCEPT_COLOURS_IN_SEQ" value="0" />
@@ -483,8 +488,8 @@
   <parameter name="V_SYNC_LENGTH" value="6" />
  </module>
  <module name="alt_vip_vfr_hdmi" kind="alt_vip_vfr" version="14.0" enabled="1">
-  <parameter name="AUTO_CLOCK_MASTER_CLOCK_RATE" value="150000000" />
-  <parameter name="AUTO_CLOCK_RESET_CLOCK_RATE" value="150000000" />
+  <parameter name="AUTO_CLOCK_MASTER_CLOCK_RATE" value="130000000" />
+  <parameter name="AUTO_CLOCK_RESET_CLOCK_RATE" value="130000000" />
   <parameter name="BITS_PER_PIXEL_PER_COLOR_PLANE" value="8" />
   <parameter name="CLOCKS_ARE_SEPARATE" value="0" />
   <parameter name="FAMILY" value="Cyclone V" />
@@ -644,7 +649,7 @@
   <parameter name="EXPORT_AFI_HALF_CLK" value="false" />
   <parameter name="EXTRA_SETTINGS" value="" />
   <parameter name="F2H_AXI_CLOCK_FREQ" value="50000000" />
-  <parameter name="F2H_SDRAM0_CLOCK_FREQ" value="150000000" />
+  <parameter name="F2H_SDRAM0_CLOCK_FREQ" value="130000000" />
   <parameter name="F2H_SDRAM1_CLOCK_FREQ" value="100" />
   <parameter name="F2H_SDRAM2_CLOCK_FREQ" value="100" />
   <parameter name="F2H_SDRAM3_CLOCK_FREQ" value="100" />
@@ -1152,7 +1157,7 @@
   <parameter name="USE_AUTO_ADDRESS_WIDTH" value="1" />
   <parameter name="USE_RESPONSE" value="0" />
  </module>
- <module name="pll_stream" kind="altera_pll" version="15.1" enabled="1">
+ <module name="pll_lcd" kind="altera_pll" version="15.1" enabled="1">
   <parameter name="debug_print_output" value="false" />
   <parameter name="debug_use_rbc_taf_method" value="false" />
   <parameter name="device" value="5CSEBA6U23I7" />
@@ -1271,8 +1276,8 @@
   <parameter name="gui_multiply_factor" value="1" />
   <parameter name="gui_number_of_clocks" value="2" />
   <parameter name="gui_operation_mode" value="normal" />
-  <parameter name="gui_output_clock_frequency0" value="150.0" />
-  <parameter name="gui_output_clock_frequency1" value="75.0" />
+  <parameter name="gui_output_clock_frequency0" value="130.0" />
+  <parameter name="gui_output_clock_frequency1" value="65.0" />
   <parameter name="gui_output_clock_frequency10" value="100.0" />
   <parameter name="gui_output_clock_frequency11" value="100.0" />
   <parameter name="gui_output_clock_frequency12" value="100.0" />
@@ -1396,7 +1401,7 @@
    start="mm_bridge_0.m0"
    end="ILC.avalon_slave">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00050000" />
+  <parameter name="baseAddress" value="0x00030000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1414,7 +1419,7 @@
    start="mm_bridge_0.m0"
    end="intr_capturer_0.avalon_slave_0">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00030000" />
+  <parameter name="baseAddress" value="0x6000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1473,7 +1478,7 @@
    start="fpga_only_master.master"
    end="ILC.avalon_slave">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00050000" />
+  <parameter name="baseAddress" value="0x00030000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1491,7 +1496,7 @@
    start="fpga_only_master.master"
    end="intr_capturer_0.avalon_slave_0">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00030000" />
+  <parameter name="baseAddress" value="0x6000" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1591,47 +1596,47 @@
    version="15.1"
    start="clk_0.clk"
    end="hps_0.h2f_lw_axi_clock" />
- <connection kind="clock" version="15.1" start="clk_0.clk" end="pll_stream.refclk" />
+ <connection kind="clock" version="15.1" start="clk_0.clk" end="pll_lcd.refclk" />
  <connection
    kind="clock"
    version="15.1"
-   start="pll_stream.outclk0"
+   start="pll_lcd.outclk0"
    end="alt_vip_vfr_hdmi.clock_master" />
  <connection
    kind="clock"
    version="15.1"
-   start="pll_stream.outclk0"
+   start="pll_lcd.outclk0"
    end="alt_vip_vfr_hdmi.clock_reset" />
  <connection
    kind="clock"
    version="15.1"
-   start="pll_stream.outclk0"
+   start="pll_lcd.outclk0"
    end="hps_0.f2h_sdram0_clock" />
  <connection
    kind="clock"
    version="15.1"
-   start="pll_stream.outclk0"
+   start="pll_lcd.outclk0"
    end="alt_vip_itc_0.is_clk_rst" />
  <connection
    kind="interrupt"
    version="15.1"
    start="hps_0.f2h_irq0"
    end="jtag_uart.irq">
-  <parameter name="irqNumber" value="2" />
+  <parameter name="irqNumber" value="0" />
  </connection>
  <connection
    kind="interrupt"
    version="15.1"
    start="hps_0.f2h_irq0"
    end="button_pio.irq">
-  <parameter name="irqNumber" value="1" />
+  <parameter name="irqNumber" value="2" />
  </connection>
  <connection
    kind="interrupt"
    version="15.1"
    start="hps_0.f2h_irq0"
    end="dipsw_pio.irq">
-  <parameter name="irqNumber" value="0" />
+  <parameter name="irqNumber" value="1" />
  </connection>
  <connection
    kind="interrupt"
@@ -1645,37 +1650,44 @@
    version="15.1"
    start="intr_capturer_0.interrupt_receiver"
    end="jtag_uart.irq">
-  <parameter name="irqNumber" value="1" />
- </connection>
- <connection
-   kind="interrupt"
-   version="15.1"
-   start="intr_capturer_0.interrupt_receiver"
-   end="dipsw_pio.irq">
-  <parameter name="irqNumber" value="2" />
+  <parameter name="irqNumber" value="0" />
  </connection>
  <connection
    kind="interrupt"
    version="15.1"
    start="intr_capturer_0.interrupt_receiver"
    end="button_pio.irq">
-  <parameter name="irqNumber" value="3" />
+  <parameter name="irqNumber" value="2" />
+ </connection>
+ <connection
+   kind="interrupt"
+   version="15.1"
+   start="intr_capturer_0.interrupt_receiver"
+   end="dipsw_pio.irq">
+  <parameter name="irqNumber" value="1" />
  </connection>
  <connection
    kind="interrupt"
    version="15.1"
    start="intr_capturer_0.interrupt_receiver"
    end="hm2reg_io_0.slv_irq">
-  <parameter name="irqNumber" value="0" />
+  <parameter name="irqNumber" value="3" />
  </connection>
  <connection kind="interrupt" version="15.1" start="ILC.irq" end="jtag_uart.irq">
-  <parameter name="irqNumber" value="2" />
+  <parameter name="irqNumber" value="0" />
  </connection>
  <connection kind="interrupt" version="15.1" start="ILC.irq" end="button_pio.irq">
-  <parameter name="irqNumber" value="1" />
+  <parameter name="irqNumber" value="2" />
  </connection>
  <connection kind="interrupt" version="15.1" start="ILC.irq" end="dipsw_pio.irq">
-  <parameter name="irqNumber" value="0" />
+  <parameter name="irqNumber" value="1" />
+ </connection>
+ <connection
+   kind="interrupt"
+   version="15.1"
+   start="ILC.irq"
+   end="hm2reg_io_0.slv_irq">
+  <parameter name="irqNumber" value="3" />
  </connection>
  <connection
    kind="reset"
@@ -1731,7 +1743,7 @@
    kind="reset"
    version="15.1"
    start="clk_0.clk_reset"
-   end="pll_stream.reset" />
+   end="pll_lcd.reset" />
  <connection
    kind="reset"
    version="15.1"
@@ -1751,12 +1763,223 @@
  <connection
    kind="reset"
    version="15.1"
+   start="hps_0.h2f_reset"
+   end="fpga_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="hps_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="alt_vip_vfr_hdmi.clock_master_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="alt_vip_vfr_hdmi.clock_reset_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="alt_vip_itc_0.is_clk_rst_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="button_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="dipsw_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="hm2reg_io_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="jtag_uart.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="led_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="mm_bridge_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="pll_lcd.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="sysid_qsys.reset" />
+ <connection kind="reset" version="15.1" start="hps_0.h2f_reset" end="ILC.reset_n" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_0.h2f_reset"
+   end="intr_capturer_0.reset_sink" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="fpga_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="fpga_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="hps_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="hps_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="alt_vip_vfr_hdmi.clock_master_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="alt_vip_vfr_hdmi.clock_master_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="alt_vip_vfr_hdmi.clock_reset_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="alt_vip_vfr_hdmi.clock_reset_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="alt_vip_itc_0.is_clk_rst_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="alt_vip_itc_0.is_clk_rst_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
    start="fpga_only_master.master_reset"
    end="hm2reg_io_0.reset" />
  <connection
    kind="reset"
    version="15.1"
    start="fpga_only_master.master_reset"
+   end="button_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="button_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="dipsw_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="dipsw_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="hm2reg_io_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="jtag_uart.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="jtag_uart.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="led_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="led_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="mm_bridge_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="mm_bridge_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="pll_lcd.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="pll_lcd.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="sysid_qsys.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="sysid_qsys.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="ILC.reset_n" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="ILC.reset_n" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="intr_capturer_0.reset_sink" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
    end="intr_capturer_0.reset_sink" />
  <interconnectRequirement for="$system" name="qsys_mm.clockCrossingAdapter" value="HANDSHAKE" />
  <interconnectRequirement for="$system" name="qsys_mm.maxAdditionalLatency" value="1" />

--- a/HW/QuartusProjects/DE10_Nano_FB_Cramps/soc_system.qsys
+++ b/HW/QuartusProjects/DE10_Nano_FB_Cramps/soc_system.qsys
@@ -427,6 +427,11 @@
  <interface name="hps_0_f2h_debug_reset_req" internal="hps_0.f2h_debug_reset_req" />
  <interface name="hps_0_f2h_stm_hw_events" internal="hps_0.f2h_stm_hw_events" />
  <interface name="hps_0_f2h_warm_reset_req" internal="hps_0.f2h_warm_reset_req" />
+ <interface
+   name="hps_0_h2f_reset"
+   internal="hps_0.h2f_reset"
+   type="reset"
+   dir="start" />
  <interface name="hps_0_hps_io" internal="hps_0.hps_io" type="conduit" dir="end" />
  <interface name="lcd_clk" internal="pll_lcd.outclk1" type="clock" dir="start" />
  <interface
@@ -1763,77 +1768,6 @@
  <connection
    kind="reset"
    version="15.1"
-   start="hps_0.h2f_reset"
-   end="fpga_only_master.clk_reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="hps_only_master.clk_reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="alt_vip_vfr_hdmi.clock_master_reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="alt_vip_vfr_hdmi.clock_reset_reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="alt_vip_itc_0.is_clk_rst_reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="button_pio.reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="dipsw_pio.reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="hm2reg_io_0.reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="jtag_uart.reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="led_pio.reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="mm_bridge_0.reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="pll_lcd.reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="sysid_qsys.reset" />
- <connection kind="reset" version="15.1" start="hps_0.h2f_reset" end="ILC.reset_n" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_0.h2f_reset"
-   end="intr_capturer_0.reset_sink" />
- <connection
-   kind="reset"
-   version="15.1"
    start="fpga_only_master.master_reset"
    end="fpga_only_master.clk_reset" />
  <connection
@@ -1885,11 +1819,6 @@
    kind="reset"
    version="15.1"
    start="fpga_only_master.master_reset"
-   end="hm2reg_io_0.reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="fpga_only_master.master_reset"
    end="button_pio.reset" />
  <connection
    kind="reset"
@@ -1906,11 +1835,6 @@
    version="15.1"
    start="hps_only_master.master_reset"
    end="dipsw_pio.reset" />
- <connection
-   kind="reset"
-   version="15.1"
-   start="hps_only_master.master_reset"
-   end="hm2reg_io_0.reset" />
  <connection
    kind="reset"
    version="15.1"
@@ -1961,6 +1885,16 @@
    version="15.1"
    start="hps_only_master.master_reset"
    end="sysid_qsys.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="hm2reg_io_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="hm2reg_io_0.reset" />
  <connection
    kind="reset"
    version="15.1"

--- a/HW/QuartusProjects/DE10_Nano_FB_Cramps/soc_system.qsys
+++ b/HW/QuartusProjects/DE10_Nano_FB_Cramps/soc_system.qsys
@@ -63,7 +63,7 @@
    {
       datum _sortIndex
       {
-         value = "10";
+         value = "11";
          type = "int";
       }
       datum sopceditor_expanded
@@ -102,7 +102,7 @@
    {
       datum _sortIndex
       {
-         value = "9";
+         value = "10";
          type = "int";
       }
       datum sopceditor_expanded
@@ -212,7 +212,7 @@
    {
       datum _sortIndex
       {
-         value = "11";
+         value = "6";
          type = "int";
       }
    }
@@ -225,7 +225,7 @@
       }
       datum baseAddress
       {
-         value = "24576";
+         value = "28416";
          type = "String";
       }
    }
@@ -233,7 +233,7 @@
    {
       datum _sortIndex
       {
-         value = "7";
+         value = "8";
          type = "int";
       }
       datum sopceditor_expanded
@@ -259,7 +259,7 @@
    {
       datum _sortIndex
       {
-         value = "8";
+         value = "9";
          type = "int";
       }
       datum sopceditor_expanded
@@ -349,7 +349,7 @@
    {
       datum _sortIndex
       {
-         value = "6";
+         value = "7";
          type = "int";
       }
       datum sopceditor_expanded
@@ -1424,7 +1424,7 @@
    start="mm_bridge_0.m0"
    end="intr_capturer_0.avalon_slave_0">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x6000" />
+  <parameter name="baseAddress" value="0x6f00" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection
@@ -1501,7 +1501,7 @@
    start="fpga_only_master.master"
    end="intr_capturer_0.avalon_slave_0">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x6000" />
+  <parameter name="baseAddress" value="0x6f00" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection

--- a/HW/QuartusProjects/DE10_Nano_SoC_FB_DB25/DE10_Nano_SoC_FB_DB25.vhd
+++ b/HW/QuartusProjects/DE10_Nano_SoC_FB_DB25/DE10_Nano_SoC_FB_DB25.vhd
@@ -52,7 +52,7 @@ entity DE10_Nano_SoC_FB_DB25 is
         HDMI_TX_HS         : out std_logic;
         HDMI_TX_INT        : in std_logic;
         HDMI_TX_VS         : out std_logic;
-        
+
         --------- ADC ---------
         ADC_CONVST         : out   std_logic;
         ADC_SCK            : out   std_logic;
@@ -291,13 +291,6 @@ begin
         mk_io_hm2_int_in                        => irq,                     --                               .hm2_int_in
         clk_100mhz_out_clk                      => hm_clk_med,              --                 clk_100mhz_out.clk
         clk_200mhz_out_clk                      => hm_clk_high,             --                 clk_100mhz_out.clk
-        adc_io_convst                           => ADC_CONVST,              --                            adc.CONVST
-        adc_io_sck                              => ADC_SCK,                 --                               .SCK
-        adc_io_sdi                              => ADC_SDI,                 --                               .SDI
-        adc_io_sdo                              => ADC_SDO,                 --                               .SDO
---      axi_str_data                            => out_data[7:0],           --                    stream_port.data
---      axi_str_valid                           => out_data[8],             --                               .valid
---      axi_str_ready                           => ar_in_sig[1])            --                               .ready
         alt_vip_itc_0_clocked_video_vid_clk     => lcd_clk,           -- alt_vip_itc_0_clocked_video.vid_clk
         alt_vip_itc_0_clocked_video_vid_data (23 downto 0)     => HDMI_TX_D,             --                            .vid_data
 --      alt_vip_itc_0_clocked_video_underflow     => CONNECTED_TO_alt_vip_itc_0_clocked_video_underflow,     --                            .underflow
@@ -386,12 +379,12 @@ begin
 
     I2C_HDMI_Config_inst : I2C_HDMI_Config
    port map (
-        iCLK        => fpga_clk_50, 
+        iCLK        => fpga_clk_50,
         iRST_N      => '1',
         I2C_SCLK    => HDMI_I2C_SCL,
         I2C_SDAT    => HDMI_I2C_SDA,
         HDMI_TX_INT => HDMI_TX_INT
---        READY       => 
+--        READY       =>
         );
 
 

--- a/HW/QuartusProjects/DE10_Nano_SoC_FB_DB25/README.md
+++ b/HW/QuartusProjects/DE10_Nano_SoC_FB_DB25/README.md
@@ -1,0 +1,8 @@
+This project is a clone of the DE0_Nano_SoC_DB25 project only with an added framebuffer driving the HDMI output.
+
+The current screen resolution is: 1024x768x8bpp @60Hz.
+
+
+The frame reader runs on a separate bus (f2h_sdram) as bus master, making it noticably faster than a cpu alone fb.
+
+This project uses the hm2 config files from the DE0_Nano_SoC_DB25 project folder, so it will run with the same hm2 soc configs.

--- a/HW/QuartusProjects/DE10_Nano_SoC_FB_DB25/soc_system.qsys
+++ b/HW/QuartusProjects/DE10_Nano_SoC_FB_DB25/soc_system.qsys
@@ -9,27 +9,11 @@
    categories="System" />
  <parameter name="bonusData"><![CDATA[bonusData 
 {
-   element adc_ltc2308_fifo_0
-   {
-      datum _sortIndex
-      {
-         value = "17";
-         type = "int";
-      }
-   }
-   element adc_ltc2308_fifo_0.slave
-   {
-      datum baseAddress
-      {
-         value = "327680";
-         type = "String";
-      }
-   }
    element alt_vip_itc_0
    {
       datum _sortIndex
       {
-         value = "1";
+         value = "15";
          type = "int";
       }
    }
@@ -37,7 +21,7 @@
    {
       datum _sortIndex
       {
-         value = "0";
+         value = "14";
          type = "int";
       }
    }
@@ -58,7 +42,7 @@
    {
       datum _sortIndex
       {
-         value = "7";
+         value = "11";
          type = "int";
       }
       datum sopceditor_expanded
@@ -84,7 +68,7 @@
    {
       datum _sortIndex
       {
-         value = "15";
+         value = "0";
          type = "int";
       }
       datum sopceditor_expanded
@@ -97,7 +81,7 @@
    {
       datum _sortIndex
       {
-         value = "3";
+         value = "2";
          type = "int";
       }
    }
@@ -105,7 +89,7 @@
    {
       datum _sortIndex
       {
-         value = "8";
+         value = "10";
          type = "int";
       }
       datum sopceditor_expanded
@@ -139,7 +123,7 @@
    {
       datum _sortIndex
       {
-         value = "12";
+         value = "5";
          type = "int";
       }
       datum sopceditor_expanded
@@ -158,6 +142,11 @@
    }
    element hm2reg_io_0.slave
    {
+      datum _lockedAddress
+      {
+         value = "1";
+         type = "boolean";
+      }
       datum baseAddress
       {
          value = "262144";
@@ -165,6 +154,32 @@
       }
    }
    element hps_0
+   {
+      datum _sortIndex
+      {
+         value = "3";
+         type = "int";
+      }
+      datum sopceditor_expanded
+      {
+         value = "1";
+         type = "boolean";
+      }
+   }
+   element hps_0.f2h_axi_slave
+   {
+      datum _lockedAddress
+      {
+         value = "0";
+         type = "boolean";
+      }
+      datum baseAddress
+      {
+         value = "0";
+         type = "String";
+      }
+   }
+   element hps_only_master
    {
       datum _sortIndex
       {
@@ -177,37 +192,21 @@
          type = "boolean";
       }
    }
-   element hps_0.f2h_axi_slave
-   {
-      datum baseAddress
-      {
-         value = "0";
-         type = "String";
-      }
-   }
-   element hps_only_master
-   {
-      datum _sortIndex
-      {
-         value = "5";
-         type = "int";
-      }
-      datum sopceditor_expanded
-      {
-         value = "1";
-         type = "boolean";
-      }
-   }
    element intr_capturer_0
    {
       datum _sortIndex
       {
-         value = "14";
+         value = "13";
          type = "int";
       }
    }
    element intr_capturer_0.avalon_slave_0
    {
+      datum _lockedAddress
+      {
+         value = "1";
+         type = "boolean";
+      }
       datum baseAddress
       {
          value = "196608";
@@ -218,7 +217,7 @@
    {
       datum _sortIndex
       {
-         value = "11";
+         value = "8";
          type = "int";
       }
       datum sopceditor_expanded
@@ -270,7 +269,7 @@
    {
       datum _sortIndex
       {
-         value = "13";
+         value = "6";
          type = "int";
       }
    }
@@ -286,12 +285,17 @@
    {
       datum _sortIndex
       {
-         value = "10";
+         value = "12";
          type = "int";
       }
    }
    element onchip_memory2_0.s1
    {
+      datum _lockedAddress
+      {
+         value = "1";
+         type = "boolean";
+      }
       datum baseAddress
       {
          value = "65536";
@@ -302,7 +306,7 @@
    {
       datum _sortIndex
       {
-         value = "2";
+         value = "1";
          type = "int";
       }
    }
@@ -318,7 +322,7 @@
    {
       datum _sortIndex
       {
-         value = "6";
+         value = "7";
          type = "int";
       }
       datum sopceditor_expanded
@@ -361,11 +365,6 @@
  <parameter name="timeStamp" value="0" />
  <parameter name="useTestBenchNamingPattern" value="false" />
  <instanceScript></instanceScript>
- <interface
-   name="adc_io"
-   internal="adc_ltc2308_fifo_0.conduit_end"
-   type="conduit"
-   dir="end" />
  <interface
    name="alt_vip_itc_0_clocked_video"
    internal="alt_vip_itc_0.clocked_video"
@@ -427,11 +426,6 @@
  <interface name="memory" internal="hps_0.memory" type="conduit" dir="end" />
  <interface name="mk_io" internal="hm2reg_io_0.pins" type="conduit" dir="end" />
  <interface name="reset" internal="clk_0.clk_in_reset" type="reset" dir="end" />
- <module
-   name="adc_ltc2308_fifo_0"
-   kind="adc_ltc2308_fifo"
-   version="1.1"
-   enabled="1" />
  <module name="alt_vip_itc_0" kind="alt_vip_itc" version="14.0" enabled="1">
   <parameter name="ACCEPT_COLOURS_IN_SEQ" value="0" />
   <parameter name="ANC_LINE" value="0" />
@@ -469,8 +463,8 @@
   <parameter name="V_SYNC_LENGTH" value="6" />
  </module>
  <module name="alt_vip_vfr_hdmi" kind="alt_vip_vfr" version="14.0" enabled="1">
-  <parameter name="AUTO_CLOCK_MASTER_CLOCK_RATE" value="100000000" />
-  <parameter name="AUTO_CLOCK_RESET_CLOCK_RATE" value="100000000" />
+  <parameter name="AUTO_CLOCK_MASTER_CLOCK_RATE" value="130000000" />
+  <parameter name="AUTO_CLOCK_RESET_CLOCK_RATE" value="130000000" />
   <parameter name="BITS_PER_PIXEL_PER_COLOR_PLANE" value="8" />
   <parameter name="CLOCKS_ARE_SEPARATE" value="0" />
   <parameter name="FAMILY" value="Cyclone V" />
@@ -639,7 +633,7 @@
   <parameter name="EXPORT_AFI_HALF_CLK" value="false" />
   <parameter name="EXTRA_SETTINGS" value="" />
   <parameter name="F2H_AXI_CLOCK_FREQ" value="50000000" />
-  <parameter name="F2H_SDRAM0_CLOCK_FREQ" value="100000000" />
+  <parameter name="F2H_SDRAM0_CLOCK_FREQ" value="130000000" />
   <parameter name="F2H_SDRAM1_CLOCK_FREQ" value="100" />
   <parameter name="F2H_SDRAM2_CLOCK_FREQ" value="100" />
   <parameter name="F2H_SDRAM3_CLOCK_FREQ" value="100" />
@@ -1476,15 +1470,6 @@
  <connection
    kind="avalon"
    version="15.1"
-   start="mm_bridge_0.m0"
-   end="adc_ltc2308_fifo_0.slave">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00050000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="15.1"
    start="fpga_only_master.master"
    end="jtag_uart.avalon_jtag_slave">
   <parameter name="arbitrationPriority" value="1" />
@@ -1558,15 +1543,6 @@
    kind="avalon"
    version="15.1"
    start="fpga_only_master.master"
-   end="adc_ltc2308_fifo_0.slave">
-  <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00050000" />
-  <parameter name="defaultConnection" value="false" />
- </connection>
- <connection
-   kind="avalon"
-   version="15.1"
-   start="fpga_only_master.master"
    end="hm2reg_io_0.slave">
   <parameter name="arbitrationPriority" value="1" />
   <parameter name="baseAddress" value="0x00040000" />
@@ -1608,11 +1584,6 @@
    kind="clock"
    version="15.1"
    start="clk_0.clk"
-   end="adc_ltc2308_fifo_0.clock_sink" />
- <connection
-   kind="clock"
-   version="15.1"
-   start="clk_0.clk"
    end="hps_0.f2h_axi_clock" />
  <connection
    kind="clock"
@@ -1629,32 +1600,27 @@
    kind="clock"
    version="15.1"
    start="hps_0.h2f_user0_clock"
-   end="alt_vip_vfr_hdmi.clock_master" />
- <connection
-   kind="clock"
-   version="15.1"
-   start="hps_0.h2f_user0_clock"
-   end="alt_vip_vfr_hdmi.clock_reset" />
- <connection
-   kind="clock"
-   version="15.1"
-   start="hps_0.h2f_user0_clock"
-   end="hps_0.f2h_sdram0_clock" />
- <connection
-   kind="clock"
-   version="15.1"
-   start="hps_0.h2f_user0_clock"
    end="clock_bridge_0.in_clk" />
  <connection
    kind="clock"
    version="15.1"
-   start="hps_0.h2f_user0_clock"
-   end="alt_vip_itc_0.is_clk_rst" />
+   start="pll_lcd.outclk0"
+   end="alt_vip_vfr_hdmi.clock_master" />
  <connection
    kind="clock"
    version="15.1"
-   start="hps_0.h2f_user1_clock"
-   end="adc_ltc2308_fifo_0.clock_sink_adc" />
+   start="pll_lcd.outclk0"
+   end="alt_vip_vfr_hdmi.clock_reset" />
+ <connection
+   kind="clock"
+   version="15.1"
+   start="pll_lcd.outclk0"
+   end="hps_0.f2h_sdram0_clock" />
+ <connection
+   kind="clock"
+   version="15.1"
+   start="pll_lcd.outclk0"
+   end="alt_vip_itc_0.is_clk_rst" />
  <connection
    kind="interrupt"
    version="15.1"
@@ -1666,14 +1632,14 @@
    kind="interrupt"
    version="15.1"
    start="hps_0.f2h_irq0"
-   end="button_pio.irq">
+   end="dipsw_pio.irq">
   <parameter name="irqNumber" value="1" />
  </connection>
  <connection
    kind="interrupt"
    version="15.1"
    start="hps_0.f2h_irq0"
-   end="dipsw_pio.irq">
+   end="button_pio.irq">
   <parameter name="irqNumber" value="2" />
  </connection>
  <connection
@@ -1694,14 +1660,14 @@
    kind="interrupt"
    version="15.1"
    start="intr_capturer_0.interrupt_receiver"
-   end="button_pio.irq">
+   end="dipsw_pio.irq">
   <parameter name="irqNumber" value="1" />
  </connection>
  <connection
    kind="interrupt"
    version="15.1"
    start="intr_capturer_0.interrupt_receiver"
-   end="dipsw_pio.irq">
+   end="button_pio.irq">
   <parameter name="irqNumber" value="2" />
  </connection>
  <connection
@@ -1785,12 +1751,57 @@
    kind="reset"
    version="15.1"
    start="clk_0.clk_reset"
-   end="adc_ltc2308_fifo_0.reset_sink" />
+   end="intr_capturer_0.reset_sink" />
  <connection
    kind="reset"
    version="15.1"
-   start="clk_0.clk_reset"
-   end="intr_capturer_0.reset_sink" />
+   start="fpga_only_master.master_reset"
+   end="fpga_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="fpga_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="hps_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="hps_only_master.clk_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="alt_vip_vfr_hdmi.clock_master_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="alt_vip_vfr_hdmi.clock_master_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="alt_vip_vfr_hdmi.clock_reset_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="alt_vip_vfr_hdmi.clock_reset_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="alt_vip_itc_0.is_clk_rst_reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="alt_vip_itc_0.is_clk_rst_reset" />
  <connection
    kind="reset"
    version="15.1"
@@ -1800,16 +1811,96 @@
    kind="reset"
    version="15.1"
    start="fpga_only_master.master_reset"
+   end="button_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="button_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="dipsw_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="dipsw_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="hm2reg_io_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="jtag_uart.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="jtag_uart.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="led_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="led_pio.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="mm_bridge_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="mm_bridge_0.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="pll_lcd.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="pll_lcd.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="sysid_qsys.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
+   end="sysid_qsys.reset" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="fpga_only_master.master_reset"
+   end="onchip_memory2_0.reset1" />
+ <connection
+   kind="reset"
+   version="15.1"
+   start="hps_only_master.master_reset"
    end="onchip_memory2_0.reset1" />
  <connection
    kind="reset"
    version="15.1"
    start="fpga_only_master.master_reset"
-   end="adc_ltc2308_fifo_0.reset_sink" />
+   end="intr_capturer_0.reset_sink" />
  <connection
    kind="reset"
    version="15.1"
-   start="fpga_only_master.master_reset"
+   start="hps_only_master.master_reset"
    end="intr_capturer_0.reset_sink" />
  <interconnectRequirement for="$system" name="qsys_mm.clockCrossingAdapter" value="HANDSHAKE" />
  <interconnectRequirement for="$system" name="qsys_mm.maxAdditionalLatency" value="1" />

--- a/HW/QuartusProjects/DE10_Nano_SoC_FB_DB25/soc_system.qsys
+++ b/HW/QuartusProjects/DE10_Nano_SoC_FB_DB25/soc_system.qsys
@@ -42,7 +42,7 @@
    {
       datum _sortIndex
       {
-         value = "11";
+         value = "12";
          type = "int";
       }
       datum sopceditor_expanded
@@ -89,7 +89,7 @@
    {
       datum _sortIndex
       {
-         value = "10";
+         value = "11";
          type = "int";
       }
       datum sopceditor_expanded
@@ -196,7 +196,7 @@
    {
       datum _sortIndex
       {
-         value = "13";
+         value = "7";
          type = "int";
       }
    }
@@ -209,7 +209,7 @@
       }
       datum baseAddress
       {
-         value = "196608";
+         value = "3840";
          type = "String";
       }
    }
@@ -217,7 +217,7 @@
    {
       datum _sortIndex
       {
-         value = "8";
+         value = "9";
          type = "int";
       }
       datum sopceditor_expanded
@@ -243,7 +243,7 @@
    {
       datum _sortIndex
       {
-         value = "9";
+         value = "10";
          type = "int";
       }
       datum sopceditor_expanded
@@ -285,7 +285,7 @@
    {
       datum _sortIndex
       {
-         value = "12";
+         value = "13";
          type = "int";
       }
    }
@@ -322,7 +322,7 @@
    {
       datum _sortIndex
       {
-         value = "7";
+         value = "8";
          type = "int";
       }
       datum sopceditor_expanded
@@ -1482,7 +1482,7 @@
    start="fpga_only_master.master"
    end="intr_capturer_0.avalon_slave_0">
   <parameter name="arbitrationPriority" value="1" />
-  <parameter name="baseAddress" value="0x00030000" />
+  <parameter name="baseAddress" value="0x0f00" />
   <parameter name="defaultConnection" value="false" />
  </connection>
  <connection

--- a/HW/QuartusProjects/DE10_Nano_SoC_FB_DB25/soc_system_pkg.vhd
+++ b/HW/QuartusProjects/DE10_Nano_SoC_FB_DB25/soc_system_pkg.vhd
@@ -5,10 +5,6 @@ package soc_pkg is
 	-- From: soc_system/soc_system.cmp
 	component soc_system is
 		port (
-			adc_io_convst                             : out   std_logic;                                        -- convst
-			adc_io_sck                                : out   std_logic;                                        -- sck
-			adc_io_sdi                                : out   std_logic;                                        -- sdi
-			adc_io_sdo                                : in    std_logic                     := 'X';             -- sdo
 			alt_vip_itc_0_clocked_video_vid_clk       : in    std_logic                     := 'X';             -- vid_clk
 			alt_vip_itc_0_clocked_video_vid_data      : out   std_logic_vector(31 downto 0);                    -- vid_data
 			alt_vip_itc_0_clocked_video_underflow     : out   std_logic;                                        -- underflow


### PR DESCRIPTION
I also removed the ADC core from qsys, in the db25 projects  it could be relevant to place it in the hm2 core similar to in the _Cramps projects this would gain hm2 support from the drivers already placed in the hal.

Would it be relevant to hang a qsys address map up somewhere and also a verbose description of the related device-trees ?