### PR TITLE
Sserial work

### DIFF
--- a/HW/QuartusProjects/Common/bidir_io.sv
+++ b/HW/QuartusProjects/Common/bidir_io.sv
@@ -1,5 +1,5 @@
 module bidir_io
-#(parameter IOWidth=36, parameter PortNumWidth=8)
+#(parameter IOWidth=36, parameter PortNumWidth=8, parameter Mux_En = 1)
 (
     input   [PortNumWidth-1:0]  portselnum  [IOWidth-1:0],
     input   clk,
@@ -24,8 +24,14 @@ generate
 
         always @ (posedge clk)
         begin
-            io_data_in[loop] <= gpioport[portselnum[loop]];
-            outmuxdataout[loop] <= out_data[portselnum[loop]];
+            if (Mux_En == 1) begin
+                io_data_in[loop] <= gpioport[portselnum[loop]];
+                outmuxdataout[loop] <= out_data[portselnum[loop]];
+            end
+            else begin
+                io_data_in[loop] <= gpioport[loop];
+                outmuxdataout[loop] <= out_data[loop];
+            end
         end
     end
 endgenerate

--- a/HW/QuartusProjects/Common/gpio_adr_decoder_reg.sv
+++ b/HW/QuartusProjects/Common/gpio_adr_decoder_reg.sv
@@ -80,6 +80,7 @@ parameter   NumGPIO         = 2;
 parameter   Capsense        = 1;
 parameter   NumSense        = 4;
 parameter   ADC             = "";
+parameter   Mux_En          = 1;
 // local param
 parameter   IoRegWidth      = 24;
 parameter   AdcOutShift     = 2;
@@ -154,12 +155,12 @@ parameter   TotalNumregs    = Mux_regPrIOReg * NumIOAddrReg * NumPinsPrIOAddr;
     wire [NumSense-1:0] sense;
     wire                charge;
     wire [3:0]          hysteresis[NumSense-1:0];
-    
-    wire sr_delay_act; 
-    wire sr_init_delay_act; 
+
+    wire sr_delay_act;
+    wire sr_init_delay_act;
    wire sense_reset;
 //	wire sense_reset = ~reset_reg_N;
-    
+
     genvar sh;
     generate
         for(sh=0;sh<NumSense;sh=sh+1) begin : sense_hystloop
@@ -268,14 +269,14 @@ generate if (Capsense >= 1) begin
         end
         else if ( write_address ) begin
             if (busaddress_r == 10'h0304) begin
-                hysteresis_reg  <= busdata_in_r; 
+                hysteresis_reg  <= busdata_in_r;
                 reset_sr <= 1'b1;
-            end 
+            end
             else begin
-                hysteresis_reg  <= hysteresis_reg; 
+                hysteresis_reg  <= hysteresis_reg;
                 reset_sr <= 1'b0;
             end
-        end	
+        end
     end
 end
 endgenerate
@@ -287,11 +288,11 @@ endgenerate
         sr_init_delay[1] <= sr_init_delay[0];
         sr_init_delay[2] <= sr_init_delay[1];
     end
-    
+
     assign sr_delay_act = (sr_delay[1] == 1'b1 && sr_delay[0] == 1'b0)  ? 1'b1 : 1'b0;
     assign sr_init_delay_act = (sr_init_delay[2] == 1'b0 && sr_init_delay[0] == 1'b1) ? 1'b1 : 1'b0;
     assign sense_reset    = ~reset_reg_N | ~buttons[1] | sr_delay_act | sr_init_delay_act;
-    
+
     genvar il;
     generate
         for(il=0;il<NumIOAddrReg;il=il+1) begin : reg_initloop
@@ -351,7 +352,7 @@ endgenerate
 //	wire [GPIOWidth-1:0] gpio1_input_data;
 //	assign gpio_input_data[1] = {gpio1_input_data[GPIOWidth-1:5],sense,charge};
 generate if (Capsense >=1) begin
-    bidir_io #(.IOWidth(GPIOWidth * NumGPIO),.PortNumWidth(PortNumWidth)) bidir_io_inst
+    bidir_io #(.IOWidth(GPIOWidth * NumGPIO),.PortNumWidth(PortNumWidth),.Mux_En(Mux_En)) bidir_io_inst
     (
         .clk(reg_clk),
         .portselnum(portnumsel),
@@ -363,7 +364,7 @@ generate if (Capsense >=1) begin
     );
     end
     else begin
-    bidir_io #(.IOWidth(GPIOWidth * NumGPIO),.PortNumWidth(PortNumWidth)) bidir_io_inst
+    bidir_io #(.IOWidth(GPIOWidth * NumGPIO),.PortNumWidth(PortNumWidth),.Mux_En(Mux_En)) bidir_io_inst
     (
         .clk(reg_clk),
         .portselnum(portnumsel),

--- a/HW/QuartusProjects/Common/gpio_adr_decoder_reg.sv
+++ b/HW/QuartusProjects/Common/gpio_adr_decoder_reg.sv
@@ -79,6 +79,7 @@ parameter   NumGPIO         = 2;
 
 parameter   Capsense        = 1;
 parameter   NumSense        = 4;
+parameter   int Capsense_Pins[NumSense:0]   = '{40, 39, 38, 37, 36};
 parameter   ADC             = "";
 parameter   Mux_En          = 1;
 // local param
@@ -148,9 +149,9 @@ parameter   TotalNumregs    = Mux_regPrIOReg * NumIOAddrReg * NumPinsPrIOAddr;
 
 // Touch sensor:
     reg [BusWidth-1:0]  hysteresis_reg;
-    reg [1:0]sr_delay;
+    reg [1:0]           sr_delay;
     reg reset_sr;
-    reg [2:0]sr_init_delay;
+    reg [2:0]           sr_init_delay;
     reg reset_init_sr;
     wire [NumSense-1:0] sense;
     wire                charge;
@@ -158,7 +159,7 @@ parameter   TotalNumregs    = Mux_regPrIOReg * NumIOAddrReg * NumPinsPrIOAddr;
 
     wire sr_delay_act;
     wire sr_init_delay_act;
-   wire sense_reset;
+    wire sense_reset;
 //	wire sense_reset = ~reset_reg_N;
 
     genvar sh;
@@ -169,22 +170,22 @@ parameter   TotalNumregs    = Mux_regPrIOReg * NumIOAddrReg * NumPinsPrIOAddr;
     endgenerate
 
 
-adc_ltc2308_fifo adc_ltc2308_fifo_inst
-(
-    .clock(CLOCK) ,	// input  clock_sig
-    .reset_n(reset_reg_N) ,	// input  reset_n_sig
-    .addr(busaddress[2]) ,	// input  addr_sig
-    .read_outdata(adc_read_valid) ,	// input  read_sig
-    .write(adc_write_valid) ,	// input  write_sig
-    .readdataout(adc_data_out) ,	// output [31:0] readdataout_sig
-    .writedatain(busdata_in) ,	// input [31:0] writedatain_sig
-//ADC
-    .adc_clk(adc_clk) ,	// input  adc_clk_sig
-    .ADC_CONVST_o(ADC_CONVST_o) ,	// output  ADC_CONVST_o_sig
-    .ADC_SCK_o(ADC_SCK_o) ,	// output  ADC_SCK_o_sig
-    .ADC_SDI_o(ADC_SDI_o) ,	// output  ADC_SDI_o_sig
-    .ADC_SDO_i(ADC_SDO_i) 	// input  ADC_SDO_i_sig
-);
+    adc_ltc2308_fifo adc_ltc2308_fifo_inst
+    (
+        .clock(CLOCK) ,	// input  clock_sig
+        .reset_n(reset_reg_N) ,	// input  reset_n_sig
+        .addr(busaddress[2]) ,	// input  addr_sig
+        .read_outdata(adc_read_valid) ,	// input  read_sig
+        .write(adc_write_valid) ,	// input  write_sig
+        .readdataout(adc_data_out) ,	// output [31:0] readdataout_sig
+        .writedatain(busdata_in) ,	// input [31:0] writedatain_sig
+    //ADC
+        .adc_clk(adc_clk) ,	// input  adc_clk_sig
+        .ADC_CONVST_o(ADC_CONVST_o) ,	// output  ADC_CONVST_o_sig
+        .ADC_SCK_o(ADC_SCK_o) ,	// output  ADC_SCK_o_sig
+        .ADC_SDI_o(ADC_SDI_o) ,	// output  ADC_SDI_o_sig
+        .ADC_SDO_i(ADC_SDO_i) 	// input  ADC_SDO_i_sig
+    );
 
 
 // I/O stuff:
@@ -260,26 +261,27 @@ adc_ltc2308_fifo adc_ltc2308_fifo_inst
     assign mux_reg_index 	= busaddress_r - 16'h1120;
     assign mux_reg_addr		= (mux_reg_index[6:2]);
     assign mux_reg_byte		= (mux_reg_index[1:0]);
-generate if (Capsense >= 1) begin
-    // Writes:
-    always @( posedge reset_in or posedge write_address) begin
-        if (reset_in) begin
-            hysteresis_reg <= 32'h22222222;
-            reset_sr <= 1'b0;
-        end
-        else if ( write_address ) begin
-            if (busaddress_r == 10'h0304) begin
-                hysteresis_reg  <= busdata_in_r;
-                reset_sr <= 1'b1;
-            end
-            else begin
-                hysteresis_reg  <= hysteresis_reg;
+
+    generate if (Capsense >= 1) begin
+        // Writes:
+        always @( posedge reset_in or posedge write_address) begin
+            if (reset_in) begin
+                hysteresis_reg <= 32'h22222222;
                 reset_sr <= 1'b0;
+            end
+            else if ( write_address ) begin
+                if (busaddress_r == 10'h0304) begin
+                    hysteresis_reg  <= busdata_in_r;
+                    reset_sr <= 1'b1;
+                end
+                else begin
+                    hysteresis_reg  <= hysteresis_reg;
+                    reset_sr <= 1'b0;
+                end
             end
         end
     end
-end
-endgenerate
+    endgenerate
 
     always @(posedge reg_clk) begin
         sr_delay[0] <= reset_sr;
@@ -327,55 +329,68 @@ endgenerate
             end
         end
     endgenerate
-/*
-    genvar bloop;
+
+    wire [((GPIOWidth * NumGPIO)-1):0] gpio_out_data;
+    genvar cl,ci0,ci1;
     generate
-        for(bloop=0;bloop<NumGPIO;bloop=bloop+1) begin : gpiooutloop
-            bidir_io #(.IOWidth(GPIOWidth),.PortNumWidth(PortNumWidth)) bidir_io_inst
+        if (Capsense >=1) begin
+            for(cl=0;cl<(GPIOWidth * NumGPIO)-1;cl++) begin : capsenseloop
+        //            .out_data({iodatafromhm3[1][GPIOWidth-1:5],4'bz,charge, iodatafromhm3[0]}) ,  // input [IOIOWidth-1:0] out_data_sig
+                if(cl<=35) begin
+                    if (Capsense_Pins[0] == cl) begin
+                        assign gpio_out_data[cl] = charge;
+                    end
+                    else begin
+                        for(ci0=1;ci0<NumSense+1;ci0++)begin : capsense0loop
+                            if(Capsense_Pins[ci0] == cl) begin
+                                assign gpio_out_data[cl] = 1'bz;
+                            end
+                            else begin
+                                assign gpio_out_data[cl] = iodatafromhm3[0][cl];
+                            end
+                        end
+                    end
+                end
+                else begin
+                    if (Capsense_Pins[0] == cl) begin
+                        assign gpio_out_data[cl] = charge;
+                    end
+                    else begin
+                        for(ci1=1;ci1<NumSense+1;ci1++) begin : capsense1loop
+                            if(Capsense_Pins[ci1] == cl) begin
+                                assign gpio_out_data[cl] = 1'bz;
+                            end
+                            else begin
+                                assign gpio_out_data[cl] = iodatafromhm3[1][cl-36];
+                            end
+                        end
+                    end
+                end
+            end
+            bidir_io #(.IOWidth(GPIOWidth * NumGPIO),.PortNumWidth(PortNumWidth),.Mux_En(Mux_En)) bidir_io_inst
             (
                 .clk(reg_clk),
-                .portselnum(portnumsel[bloop]),
-                .out_ena(out_ena[bloop]) ,	// input  out_ena_sig
-                .od(od[bloop]) ,	// input  od_sig
-                .out_data(iodatafromhm3[bloop]) ,  // input [IOIOWidth-1:0] out_data_sig
-                .gpioport(gpioport[bloop]) ,	// inout [IOIOWidth-1:0] gpioport_sig
-                .gpio_in_data(gpio_input_data[bloop]) 	// output [IOIOWidth-1:0] read_data_sig
+                .portselnum(portnumsel),
+                .out_ena({out_ena[1],out_ena[0]}) ,	// input  out_ena_sig
+                .od({od[1],od[0]}) ,	// input  od_sig
+                .out_data(gpio_out_data) ,  // input [IOIOWidth-1:0] out_data_sig
+                .gpioport({gpioport[1],gpioport[0]}) ,	// inout [IOIOWidth-1:0] gpioport_sig
+                .data_from_gpio({gpio_input_data[1],gpio_input_data[0]}) 	// output [IOIOWidth-1:0] read_data_sig
             );
-//			defparam bidir_io_inst[il].IOWidth = GPIOWidth;
-//			defparam bidir_io_inst[il].PortNumWidth = PortNumWidth;
+            end
+        else begin
+            bidir_io #(.IOWidth(GPIOWidth * NumGPIO),.PortNumWidth(PortNumWidth),.Mux_En(Mux_En)) bidir_io_inst
+            (
+                .clk(reg_clk),
+                .portselnum(portnumsel),
+                .out_ena({out_ena[1],out_ena[0]}) ,	// input  out_ena_sig
+                .od({od[1],od[0]}) ,	// input  od_sig
+                .out_data({iodatafromhm3[1], iodatafromhm3[0]}) ,  // input [IOIOWidth-1:0] out_data_sig
+                .gpioport({gpioport[1],gpioport[0]}) ,	// inout [IOIOWidth-1:0] gpioport_sig
+                .data_from_gpio({gpio_input_data[1],gpio_input_data[0]}) 	// output [IOIOWidth-1:0] read_data_sig
+            );
         end
     endgenerate
-*/
-
-//	wire [GPIOWidth-1:0] gpio1_data_fromhm3 = iodatafromhm3[1];
-//	wire [GPIOWidth-1:0] gpio1_out_data = {gpio1_data_fromhm3[GPIOWidth-1:5],4'bz,charge};
-//	wire [GPIOWidth-1:0] gpio1_input_data;
-//	assign gpio_input_data[1] = {gpio1_input_data[GPIOWidth-1:5],sense,charge};
-generate if (Capsense >=1) begin
-    bidir_io #(.IOWidth(GPIOWidth * NumGPIO),.PortNumWidth(PortNumWidth),.Mux_En(Mux_En)) bidir_io_inst
-    (
-        .clk(reg_clk),
-        .portselnum(portnumsel),
-        .out_ena({out_ena[1],out_ena[0]}) ,	// input  out_ena_sig
-        .od({od[1],od[0]}) ,	// input  od_sig
-        .out_data({iodatafromhm3[1][GPIOWidth-1:5],4'bz,charge, iodatafromhm3[0]}) ,  // input [IOIOWidth-1:0] out_data_sig
-        .gpioport({gpioport[1],gpioport[0]}) ,	// inout [IOIOWidth-1:0] gpioport_sig
-        .data_from_gpio({gpio_input_data[1],gpio_input_data[0]}) 	// output [IOIOWidth-1:0] read_data_sig
-    );
-    end
-    else begin
-    bidir_io #(.IOWidth(GPIOWidth * NumGPIO),.PortNumWidth(PortNumWidth),.Mux_En(Mux_En)) bidir_io_inst
-    (
-        .clk(reg_clk),
-        .portselnum(portnumsel),
-        .out_ena({out_ena[1],out_ena[0]}) ,	// input  out_ena_sig
-        .od({od[1],od[0]}) ,	// input  od_sig
-        .out_data({iodatafromhm3[1], iodatafromhm3[0]}) ,  // input [IOIOWidth-1:0] out_data_sig
-        .gpioport({gpioport[1],gpioport[0]}) ,	// inout [IOIOWidth-1:0] gpioport_sig
-        .data_from_gpio({gpio_input_data[1],gpio_input_data[0]}) 	// output [IOIOWidth-1:0] read_data_sig
-    );
-    end
-endgenerate
     // Read:
 
     integer oo,om,oi;
@@ -414,8 +429,8 @@ endgenerate
                 else begin busdata_to_cpu <= busdata_fromhm2; end
             end else begin
                 if (adc_address_valid) begin busdata_to_cpu <= adc_data_out;	end
-//			    if ((busaddress_r == 'h0200) || (busaddress_r == 'h0204)) begin busdata_to_cpu <= adc_data_out;	end
-                else if (busaddress_r == 'h0304) begin busdata_to_cpu <= hysteresis_reg;	end
+//			      else if (busaddress_r == 'h0300) begin busdata_to_cpu <= touched; reset_init_sr <= 1'b1;	end
+//                else if (busaddress_r == 'h0304) begin busdata_to_cpu <= hysteresis_reg;	end
                 else if(busaddress_r == 'h1000) begin busdata_to_cpu <= {8'b0,gpio_input_data[0][23:0]}; end
                 else if(busaddress_r == 'h1004) begin busdata_to_cpu <= {8'b0,gpio_input_data[1][11:0],gpio_input_data[0][35:24]}; end
                 else if(busaddress_r == 'h1008) begin busdata_to_cpu <= {8'b0,gpio_input_data[1][35:12]}; end
@@ -442,30 +457,30 @@ endgenerate
     end
     endgenerate
 
-generate if (Capsense >=1) begin
-    assign sense = gpio_input_data[1][5:1];
+    generate if (Capsense >=1) begin
+        assign sense = gpio_input_data[1][5:1];
 
-            capsense capsense_inst
-        (
-            .clk(reg_clk) ,	// input  clk_sig
-            .reset(sense_reset) ,	// input  reset_sig
-            .sense(sense) ,	// input [num-1:0] sense_sig
-            .hysteresis(hysteresis),
-//            .calibval_0(calibval_0),
-//            .counts_0(counts_0),
-            .charge(charge) ,	// output  charge_sig
-            .touched(touched) 	// output [num-1:0] touched_sig
-        );
+                capsense capsense_inst
+            (
+                .clk(reg_clk) ,	// input  clk_sig
+                .reset(sense_reset) ,	// input  reset_sig
+                .sense(sense) ,	// input [num-1:0] sense_sig
+                .hysteresis(hysteresis),
+    //            .calibval_0(calibval_0),
+    //            .counts_0(counts_0),
+                .charge(charge) ,	// output  charge_sig
+                .touched(touched) 	// input [num-1:0] touched_sig
+            );
 
-        defparam capsense_inst.num = NumSense;
-        // States
-        defparam capsense_inst.CHARGE = 1;
-        defparam capsense_inst.DISCHARGE = 2;
-        // freqwuency in Mhz  , times in us
-        defparam capsense_inst.clockfrequency = 200;
-        defparam capsense_inst.periodtime = 5;
-    end
-endgenerate
+            defparam capsense_inst.num = NumSense;
+            // States
+            defparam capsense_inst.CHARGE = 1;
+            defparam capsense_inst.DISCHARGE = 2;
+            // freqwuency in Mhz  , times in us
+            defparam capsense_inst.clockfrequency = 200;
+            defparam capsense_inst.periodtime = 5;
+        end
+    endgenerate
 
 endmodule
 

--- a/HW/QuartusProjects/DE0_Nano_SoC_Cramps/DE0_Nano_SoC_Cramps.sv
+++ b/HW/QuartusProjects/DE0_Nano_SoC_Cramps/DE0_Nano_SoC_Cramps.sv
@@ -356,6 +356,7 @@ defparam gpio_adr_decoder_reg_inst.NumGPIO = NumGPIO;
 defparam gpio_adr_decoder_reg_inst.ADC = ADC;
 defparam gpio_adr_decoder_reg_inst.Capsense = Capsense;
 defparam gpio_adr_decoder_reg_inst.NumSense = NumSense;
+defparam gpio_adr_decoder_reg_inst.Capsense_Pins = Capsense_Pins;
 
 HostMot3_cfg HostMot3_inst
 (

--- a/HW/QuartusProjects/DE0_Nano_SoC_Cramps/DE0_Nano_SoC_Cramps.sv
+++ b/HW/QuartusProjects/DE0_Nano_SoC_Cramps/DE0_Nano_SoC_Cramps.sv
@@ -160,8 +160,6 @@ parameter NumIOAddrReg = 6;
     wire                    hm_clk_high;
     wire                    adc_clk_40;
 //    wire                    clklow_sig;
-    wire                    clkmed_sig;
-    wire                    clkhigh_sig;
 
 // Mesa I/O Signals:
     wire [LEDCount-1:0]         hm2_leds_sig;
@@ -315,10 +313,6 @@ defparam top_io_modules_inst.KEY_WIDTH = 2;
 
 // Mesa code ------------------------------------------------------//
 
-assign clkhigh_sig = hm_clk_high;
-assign clkmed_sig = hm_clk_med;
-
-
 genvar ig;
 generate for(ig=0;ig<NumGPIO;ig=ig+1) begin : iosigloop
     assign io_bitsout_sig[ig] = hm2_bitsout_sig[(ig*MuxGPIOIOWidth)+:MuxGPIOIOWidth];
@@ -329,7 +323,7 @@ endgenerate
 gpio_adr_decoder_reg gpio_adr_decoder_reg_inst
 (
     .CLOCK(fpga_clk_50) ,	// input  CLOCK_sig
-    .reg_clk(clkhigh_sig) ,	// input  CLOCK_sig
+    .reg_clk(hm_clk_high) ,	// input  CLOCK_sig
     .reset_reg_N(hps_fpga_reset_n) ,	// input  reset_reg_N_sig
     .chip_sel(hm_chipsel[0]) ,	// input  data_ready_sig
     .write_reg(hm_write) ,	// input  data_ready_sig
@@ -372,8 +366,8 @@ HostMot3_cfg HostMot3_inst
     .writestb(hm_write) ,	// input  writestb_sig
 
     .clklow(fpga_clk_50) ,	// input  clklow_sig  				-- PCI clock --> all
-    .clkmed(clkmed_sig) ,	// input  clkmed_sig  				-- Processor clock --> sserialwa, twiddle
-    .clkhigh(clkhigh_sig) ,	// input  clkhigh_sig				-- High speed clock --> most
+    .clkmed(hm_clk_med) ,	// input  hm_clk_med  				-- Processor clock --> sserialwa, twiddle
+    .clkhigh(hm_clk_high) ,	// input  hm_clk_high				-- High speed clock --> most
     .intirq(int_sig) ,	// output  int_sig							--int => LINT, ---> PCI ?
     .iobitsouttop(hm2_bitsout_sig) ,	// inout [IOWidth-1:0] 				--iobits => IOBITS,-- external I/O bits
     .iobitsintop(hm2_bitsin_sig) 	// inout [IOWidth-1:0] 				--iobits => IOBITS,-- external I/O bits

--- a/HW/QuartusProjects/DE10_Nano_FB_Cramps/DE10_Nano_FB_Cramps.sv
+++ b/HW/QuartusProjects/DE10_Nano_FB_Cramps/DE10_Nano_FB_Cramps.sv
@@ -163,8 +163,6 @@ parameter NumIOAddrReg = 6;
     wire                    hm_clk_high;
     wire                    adc_clk_40;
 //    wire                    clklow_sig;
-    wire                    clkmed_sig;
-    wire                    clkhigh_sig;
 
 // Mesa I/O Signals:
     wire [LEDCount-1:0]         hm2_leds_sig;
@@ -312,10 +310,6 @@ defparam top_io_modules_inst.KEY_WIDTH = 2;
 
 // Mesa code ------------------------------------------------------//
 
-assign clkhigh_sig = hm_clk_high;
-assign clkmed_sig = hm_clk_med;
-
-
 genvar ig;
 generate for(ig=0;ig<NumGPIO;ig=ig+1) begin : iosigloop
     assign io_bitsout_sig[ig] = hm2_bitsout_sig[(ig*MuxGPIOIOWidth)+:MuxGPIOIOWidth];
@@ -369,8 +363,8 @@ HostMot3_cfg HostMot3_inst
     .writestb(hm_write) ,	// input  writestb_sig
 
     .clklow(fpga_clk_50) ,	// input  clklow_sig  				-- PCI clock --> all
-    .clkmed(clkmed_sig) ,	// input  clkmed_sig  				-- Processor clock --> sserialwa, twiddle
-    .clkhigh(clkhigh_sig) ,	// input  clkhigh_sig				-- High speed clock --> most
+    .clkmed(hm_clk_med) ,	// input  hm_clk_med  				-- Processor clock --> sserialwa, twiddle
+    .clkhigh(hm_clk_high) ,	// input  hm_clk_high				-- High speed clock --> most
     .intirq(int_sig) ,	// output  int_sig							--int => LINT, ---> PCI ?
     .iobitsouttop(hm2_bitsout_sig) ,	// inout [IOWidth-1:0] 				--iobits => IOBITS,-- external I/O bits
     .iobitsintop(hm2_bitsin_sig) 	// inout [IOWidth-1:0] 				--iobits => IOBITS,-- external I/O bits

--- a/HW/QuartusProjects/DE10_Nano_FB_Cramps/DE10_Nano_FB_Cramps.sv
+++ b/HW/QuartusProjects/DE10_Nano_FB_Cramps/DE10_Nano_FB_Cramps.sv
@@ -353,6 +353,7 @@ defparam gpio_adr_decoder_reg_inst.ADC = ADC;
 defparam gpio_adr_decoder_reg_inst.Mux_En = Mux_En;
 defparam gpio_adr_decoder_reg_inst.Capsense = Capsense;
 defparam gpio_adr_decoder_reg_inst.NumSense = NumSense;
+defparam gpio_adr_decoder_reg_inst.Capsense_Pins = Capsense_Pins;
 
 HostMot3_cfg HostMot3_inst
 (

--- a/HW/QuartusProjects/DE10_Nano_FB_Cramps/DE10_Nano_FB_Cramps.sv
+++ b/HW/QuartusProjects/DE10_Nano_FB_Cramps/DE10_Nano_FB_Cramps.sv
@@ -148,7 +148,7 @@ parameter NumIOAddrReg = 6;
 // connection of internal logics
 //	assign LED[5:1] = fpga_led_internal | {7'b0000000, led_level};
     assign LED[4:1] = touched;
-    
+
     assign fpga_clk_50=FPGA_CLK1_50;
 //    assign stm_hw_events    = {{15{1'b0}}, SW, fpga_led_internal, fpga_debounced_buttons};
 // hm2
@@ -326,7 +326,7 @@ endgenerate
 gpio_adr_decoder_reg gpio_adr_decoder_reg_inst
 (
     .CLOCK(fpga_clk_50) ,	// input  CLOCK_sig
-    .reg_clk(clkhigh_sig) ,	// input  CLOCK_sig
+    .reg_clk(hm_clk_high) ,	// input  CLOCK_sig
     .reset_reg_N(hps_fpga_reset_n) ,	// input  reset_reg_N_sig
     .chip_sel(hm_chipsel[0]) ,	// input  data_ready_sig
     .write_reg(hm_write) ,	// input  data_ready_sig
@@ -356,6 +356,7 @@ defparam gpio_adr_decoder_reg_inst.MuxGPIOIOWidth = MuxGPIOIOWidth;
 defparam gpio_adr_decoder_reg_inst.NumIOAddrReg = NumIOAddrReg;
 defparam gpio_adr_decoder_reg_inst.NumGPIO = NumGPIO;
 defparam gpio_adr_decoder_reg_inst.ADC = ADC;
+defparam gpio_adr_decoder_reg_inst.Mux_En = Mux_En;
 defparam gpio_adr_decoder_reg_inst.Capsense = Capsense;
 defparam gpio_adr_decoder_reg_inst.NumSense = NumSense;
 

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24.vhd
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24.vhd
@@ -110,81 +110,81 @@ package Pintypes is
     constant PinDesc : PinDescType :=(
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2 DE0-Nano        pin    Function
-        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 00   GPIO_0 01    01        X Step
-        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 01   GPIO_0 02    02        X Dir
-        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 02   GPIO_0 03    03        Y Step
-        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 03   GPIO_0 04    04         Y Dir
-        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 04   GPIO_0 05    05        Z Step
-        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 05   GPIO_0 06    06        Z Dir
-        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 06   GPIO_0 07    07        E0 Step
-        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 07   GPIO_0 08    08        E0 Dir
-        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 08   GPIO_0 09    09        E1 Step
-        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 09   GPIO_0 10    10        E1 Dir
-        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 10   GPIO_0 11    13        E2 Step
-        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 11   GPIO_0 12    14        E2 Dir
-        IOPortTag & x"06" & StepGenTag & StepGenStepPin,    -- I/O 12   GPIO_0 13    15        U Step
-        IOPortTag & x"06" & StepGenTag & StepGenDirPin,     -- I/O 13   GPIO_0 14    16        U Dir
-        IOPortTag & x"07" & StepGenTag & StepGenStepPin,    -- I/O 14   GPIO_0 15    17        V Step
-        IOPortTag & x"07" & StepGenTag & StepGenDirPin,     -- I/O 15   GPIO_0 16    18        V Dir
-        IOPortTag & x"08" & StepGenTag & StepGenStepPin,    -- I/O 16   GPIO_0 17    19        W Step
-        IOPortTag & x"08" & StepGenTag & StepGenDirPin,     -- I/O 17   GPIO_0 18    20        W Dir
-        IOPortTag & x"00" & PWMTag & PWMAOutPin,            -- I/O 18   GPIO_0 19    21        Spindle DAC PWM
-        IOPortTag & x"01" & PWMTag & PWMAOutPin,            -- I/O 19   GPIO_0 20    22        Spindle DAC PWM
-        IOPortTag & x"02" & PWMTag & PWMAOutPin,            -- I/O 20   GPIO_0 21    23        Spindle DAC PWM
-        IOPortTag & x"03" & PWMTag & PWMAOutPin,            -- I/O 21   GPIO_0 22    24        Spindle DAC PWM
-        IOPortTag & x"04" & PWMTag & PWMAOutPin,            -- I/O 22   GPIO_0 23    25        Spindle DAC PWM
-        IOPortTag & x"05" & PWMTag & PWMAOutPin,            -- I/O 23   GPIO_0 24    26        Spindle DAC PWM
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 24   GPIO_0 25    27        Limit X-Min
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 25   GPIO_0 26    28        Limit X-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 26   GPIO_0 27    31        Limit Y-Min
+        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 00   GPIO_0 00    01        X Step
+        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 01   GPIO_0 01    02        X Dir
+        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 02   GPIO_0 02    03        Y Step
+        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 03   GPIO_0 03    04         Y Dir
+        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 04   GPIO_0 04    05        Z Step
+        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 05   GPIO_0 05    06        Z Dir
+        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 06   GPIO_0 06    07        E0 Step
+        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 07   GPIO_0 07    08        E0 Dir
+        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 08   GPIO_0 08    09        E1 Step
+        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 09   GPIO_0 09    10        E1 Dir
+        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 10   GPIO_0 10    13        E2 Step
+        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 11   GPIO_0 11    14        E2 Dir
+        IOPortTag & x"06" & StepGenTag & StepGenStepPin,    -- I/O 12   GPIO_0 12    15        U Step
+        IOPortTag & x"06" & StepGenTag & StepGenDirPin,     -- I/O 13   GPIO_0 13    16        U Dir
+        IOPortTag & x"07" & StepGenTag & StepGenStepPin,    -- I/O 14   GPIO_0 14    17        V Step
+        IOPortTag & x"07" & StepGenTag & StepGenDirPin,     -- I/O 15   GPIO_0 15    18        V Dir
+        IOPortTag & x"08" & StepGenTag & StepGenStepPin,    -- I/O 16   GPIO_0 16    19        W Step
+        IOPortTag & x"08" & StepGenTag & StepGenDirPin,     -- I/O 17   GPIO_0 17    20        W Dir
+        IOPortTag & x"00" & PWMTag & PWMAOutPin,            -- I/O 18   GPIO_0 18    21        Spindle DAC PWM
+        IOPortTag & x"01" & PWMTag & PWMAOutPin,            -- I/O 19   GPIO_0 19    22        Spindle DAC PWM
+        IOPortTag & x"02" & PWMTag & PWMAOutPin,            -- I/O 20   GPIO_0 20    23        Spindle DAC PWM
+        IOPortTag & x"03" & PWMTag & PWMAOutPin,            -- I/O 21   GPIO_0 21    24        Spindle DAC PWM
+        IOPortTag & x"04" & PWMTag & PWMAOutPin,            -- I/O 22   GPIO_0 22    25        Spindle DAC PWM
+        IOPortTag & x"05" & PWMTag & PWMAOutPin,            -- I/O 23   GPIO_0 23    26        Spindle DAC PWM
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 24   GPIO_0 24    27        Limit X-Min
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 25   GPIO_0 25    28        Limit X-Max
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 26   GPIO_0 26    31        Limit Y-Min
         IOPortTag & x"00" & NullTag & NullPin,              -- I/O 27   GPIO_0 27    32        Limit Y-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 28   GPIO_0 29    33        Limit Z-Min
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 29   GPIO_0 30    34        Limit Z-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 30   GPIO_0 31    35        just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 31   GPIO_0 32    36        Led
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 32   GPIO_0 33    37        Axis_ENA_n
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 33   GPIO_0 34    38        Machine_Pwr
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 35    39        Estop (In)
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 36    40        Estop_Sw
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 28   GPIO_0 28    33        Limit Z-Min
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 29   GPIO_0 29    34        Limit Z-Max
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 30   GPIO_0 30    35        just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 31   GPIO_0 31    36        Led
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 32   GPIO_0 32    37        Axis_ENA_n
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 33   GPIO_0 33    38        Machine_Pwr
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 34    39        Estop (In)
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 35    40        Estop_Sw
 
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2    DE0-Nano     pin    Function
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 36    GPIO_1 01   01      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 37    GPIO_1 02   02      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 38    GPIO_1 03   03      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 39    GPIO_1 04   04      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 40    GPIO_1 05   05      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 41    GPIO_1 06   06      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 42    GPIO_1 07   07      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 43    GPIO_1 08   08      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 44    GPIO_1 09   09      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 45    GPIO_1 10   10      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 46    GPIO_1 11   13      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 47    GPIO_1 12   14      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 48    GPIO_1 13   15      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 49    GPIO_1 14   16      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 50    GPIO_1 15   17      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 51    GPIO_1 16   18      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 52    GPIO_1 17   19      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 53    GPIO_1 18   20      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 54    GPIO_1 19   21      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 55    GPIO_1 20   22      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 56    GPIO_1 21   23      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 57    GPIO_1 22   24      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 58    GPIO_1 23   25      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 59    GPIO_1 24   26      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 60    GPIO_1 25   27      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 61    GPIO_1 26   28      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 62    GPIO_1 27   31      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 63    GPIO_1 28   32      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 64    GPIO_1 29   33      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 65    GPIO_1 30   34      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 66    GPIO_1 31   35      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 67    GPIO_1 32   36      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 68    GPIO_1 33   37      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 69    GPIO_1 34   38      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 70    GPIO_1 35   39      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 71    GPIO_1 36   40      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 36    GPIO_1 00   01      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 37    GPIO_1 01   02      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 38    GPIO_1 02   03      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 39    GPIO_1 03   04      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 40    GPIO_1 04   05      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 41    GPIO_1 05   06      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 42    GPIO_1 06   07      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 43    GPIO_1 07   08      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 44    GPIO_1 08   09      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 45    GPIO_1 09   10      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 46    GPIO_1 10   13      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 47    GPIO_1 11   14      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 48    GPIO_1 12   15      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 49    GPIO_1 13   16      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 50    GPIO_1 14   17      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 51    GPIO_1 15   18      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 52    GPIO_1 16   19      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 53    GPIO_1 17   20      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 54    GPIO_1 18   21      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 55    GPIO_1 19   22      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 56    GPIO_1 20   23      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 57    GPIO_1 21   24      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 58    GPIO_1 22   25      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 59    GPIO_1 23   26      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 60    GPIO_1 24   27      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 61    GPIO_1 25   28      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 62    GPIO_1 26   31      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 63    GPIO_1 27   32      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 64    GPIO_1 28   33      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 65    GPIO_1 29   34      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 66    GPIO_1 30   35      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 67    GPIO_1 31   36      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 68    GPIO_1 32   37      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 69    GPIO_1 33   38      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 70    GPIO_1 34   39      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 71    GPIO_1 35   40      just GPIO
 
                 -- Remainder of 144 pin descriptors are unused
         emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24_cap.vhd
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24_cap.vhd
@@ -110,81 +110,81 @@ package Pintypes is
     constant PinDesc : PinDescType :=(
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2 DE0-Nano        pin    Function
-        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 00   GPIO_0 01    01        X Step
-        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 01   GPIO_0 02    02        X Dir
-        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 02   GPIO_0 03    03        Y Step
-        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 03   GPIO_0 04    04         Y Dir
-        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 04   GPIO_0 05    05        Z Step
-        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 05   GPIO_0 06    06        Z Dir
-        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 06   GPIO_0 07    07        E0 Step
-        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 07   GPIO_0 08    08        E0 Dir
-        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 08   GPIO_0 09    09        E1 Step
-        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 09   GPIO_0 10    10        E1 Dir
-        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 10   GPIO_0 11    13        E2 Step
-        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 11   GPIO_0 12    14        E2 Dir
-        IOPortTag & x"06" & StepGenTag & StepGenStepPin,    -- I/O 12   GPIO_0 13    15        U Step
-        IOPortTag & x"06" & StepGenTag & StepGenDirPin,     -- I/O 13   GPIO_0 14    16        U Dir
-        IOPortTag & x"07" & StepGenTag & StepGenStepPin,    -- I/O 14   GPIO_0 15    17        V Step
-        IOPortTag & x"07" & StepGenTag & StepGenDirPin,     -- I/O 15   GPIO_0 16    18        V Dir
-        IOPortTag & x"08" & StepGenTag & StepGenStepPin,    -- I/O 16   GPIO_0 17    19        W Step
-        IOPortTag & x"08" & StepGenTag & StepGenDirPin,     -- I/O 17   GPIO_0 18    20        W Dir
-        IOPortTag & x"00" & PWMTag & PWMAOutPin,            -- I/O 18   GPIO_0 19    21        Spindle DAC PWM
-        IOPortTag & x"01" & PWMTag & PWMAOutPin,            -- I/O 19   GPIO_0 20    22        Spindle DAC PWM
-        IOPortTag & x"02" & PWMTag & PWMAOutPin,            -- I/O 20   GPIO_0 21    23        Spindle DAC PWM
-        IOPortTag & x"03" & PWMTag & PWMAOutPin,            -- I/O 21   GPIO_0 22    24        Spindle DAC PWM
-        IOPortTag & x"04" & PWMTag & PWMAOutPin,            -- I/O 22   GPIO_0 23    25        Spindle DAC PWM
-        IOPortTag & x"05" & PWMTag & PWMAOutPin,            -- I/O 23   GPIO_0 24    26        Spindle DAC PWM
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 24   GPIO_0 25    27        Limit X-Min
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 25   GPIO_0 26    28        Limit X-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 26   GPIO_0 27    31        Limit Y-Min
+        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 00   GPIO_0 00    01        X Step
+        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 01   GPIO_0 01    02        X Dir
+        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 02   GPIO_0 02    03        Y Step
+        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 03   GPIO_0 03    04         Y Dir
+        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 04   GPIO_0 04    05        Z Step
+        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 05   GPIO_0 05    06        Z Dir
+        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 06   GPIO_0 06    07        E0 Step
+        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 07   GPIO_0 07    08        E0 Dir
+        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 08   GPIO_0 08    09        E1 Step
+        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 09   GPIO_0 09    10        E1 Dir
+        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 10   GPIO_0 10    13        E2 Step
+        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 11   GPIO_0 11    14        E2 Dir
+        IOPortTag & x"06" & StepGenTag & StepGenStepPin,    -- I/O 12   GPIO_0 12    15        U Step
+        IOPortTag & x"06" & StepGenTag & StepGenDirPin,     -- I/O 13   GPIO_0 13    16        U Dir
+        IOPortTag & x"07" & StepGenTag & StepGenStepPin,    -- I/O 14   GPIO_0 14    17        V Step
+        IOPortTag & x"07" & StepGenTag & StepGenDirPin,     -- I/O 15   GPIO_0 15    18        V Dir
+        IOPortTag & x"08" & StepGenTag & StepGenStepPin,    -- I/O 16   GPIO_0 16    19        W Step
+        IOPortTag & x"08" & StepGenTag & StepGenDirPin,     -- I/O 17   GPIO_0 17    20        W Dir
+        IOPortTag & x"00" & PWMTag & PWMAOutPin,            -- I/O 18   GPIO_0 18    21        Spindle DAC PWM
+        IOPortTag & x"01" & PWMTag & PWMAOutPin,            -- I/O 19   GPIO_0 19    22        Spindle DAC PWM
+        IOPortTag & x"02" & PWMTag & PWMAOutPin,            -- I/O 20   GPIO_0 20    23        Spindle DAC PWM
+        IOPortTag & x"03" & PWMTag & PWMAOutPin,            -- I/O 21   GPIO_0 21    24        Spindle DAC PWM
+        IOPortTag & x"04" & PWMTag & PWMAOutPin,            -- I/O 22   GPIO_0 22    25        Spindle DAC PWM
+        IOPortTag & x"05" & PWMTag & PWMAOutPin,            -- I/O 23   GPIO_0 23    26        Spindle DAC PWM
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 24   GPIO_0 24    27        Limit X-Min
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 25   GPIO_0 25    28        Limit X-Max
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 26   GPIO_0 26    31        Limit Y-Min
         IOPortTag & x"00" & NullTag & NullPin,              -- I/O 27   GPIO_0 27    32        Limit Y-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 28   GPIO_0 29    33        Limit Z-Min
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 29   GPIO_0 30    34        Limit Z-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 30   GPIO_0 31    35        just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 31   GPIO_0 32    36        Led
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 32   GPIO_0 33    37        Axis_ENA_n
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 33   GPIO_0 34    38        Machine_Pwr
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 35    39        Estop (In)
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 36    40        Estop_Sw
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 28   GPIO_0 28    33        Limit Z-Min
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 29   GPIO_0 29    34        Limit Z-Max
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 30   GPIO_0 30    35        just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 31   GPIO_0 31    36        Led
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 32   GPIO_0 32    37        Axis_ENA_n
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 33   GPIO_0 33    38        Machine_Pwr
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 34    39        Estop (In)
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 35    40        Estop_Sw
 
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2    DE0-Nano     pin    Function
-        IOPortTag & x"00" & CAPSENSETag & CapChargePin,     --    I/O 36    GPIO_1 01   01      CapSense charge
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin0,     --    I/O 37    GPIO_1 02   02      CapSense sense 0
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin1,     --    I/O 38    GPIO_1 03   03      CapSense sense 1
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin2,     --    I/O 39    GPIO_1 04   04      CapSense sense 2
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin3,     --    I/O 40    GPIO_1 05   05      CapSense sense 3
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 41    GPIO_1 06   06      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 42    GPIO_1 07   07      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 43    GPIO_1 08   08      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 44    GPIO_1 09   09      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 45    GPIO_1 10   10      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 46    GPIO_1 11   13      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 47    GPIO_1 12   14      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 48    GPIO_1 13   15      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 49    GPIO_1 14   16      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 50    GPIO_1 15   17      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 51    GPIO_1 16   18      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 52    GPIO_1 17   19      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 53    GPIO_1 18   20      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 54    GPIO_1 19   21      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 55    GPIO_1 20   22      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 56    GPIO_1 21   23      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 57    GPIO_1 22   24      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 58    GPIO_1 23   25      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 59    GPIO_1 24   26      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 60    GPIO_1 25   27      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 61    GPIO_1 26   28      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 62    GPIO_1 27   31      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 63    GPIO_1 28   32      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 64    GPIO_1 29   33      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 65    GPIO_1 30   34      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 66    GPIO_1 31   35      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 67    GPIO_1 32   36      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 68    GPIO_1 33   37      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 69    GPIO_1 34   38      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 70    GPIO_1 35   39      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 71    GPIO_1 36   40      just GPIO
+        IOPortTag & x"00" & CAPSENSETag & CapChargePin,     --    I/O 36    GPIO_1 00   01      CapSense charge
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin0,     --    I/O 37    GPIO_1 01   02      CapSense sense 0
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin1,     --    I/O 38    GPIO_1 02   03      CapSense sense 1
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin2,     --    I/O 39    GPIO_1 03   04      CapSense sense 2
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin3,     --    I/O 40    GPIO_1 04   05      CapSense sense 3
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 41    GPIO_1 05   06      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 42    GPIO_1 06   07      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 43    GPIO_1 07   08      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 44    GPIO_1 08   09      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 45    GPIO_1 09   10      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 46    GPIO_1 10   13      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 47    GPIO_1 11   14      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 48    GPIO_1 12   15      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 49    GPIO_1 13   16      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 50    GPIO_1 14   17      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 51    GPIO_1 15   18      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 52    GPIO_1 16   19      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 53    GPIO_1 17   20      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 54    GPIO_1 18   21      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 55    GPIO_1 19   22      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 56    GPIO_1 20   23      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 57    GPIO_1 21   24      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 58    GPIO_1 22   25      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 59    GPIO_1 23   26      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 60    GPIO_1 24   27      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 61    GPIO_1 25   28      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 62    GPIO_1 26   31      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 63    GPIO_1 27   32      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 64    GPIO_1 28   33      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 65    GPIO_1 29   34      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 66    GPIO_1 30   35      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 67    GPIO_1 31   36      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 68    GPIO_1 32   37      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 69    GPIO_1 33   38      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 70    GPIO_1 34   39      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 71    GPIO_1 35   40      just GPIO
 
                 -- Remainder of 144 pin descriptors are unused
         emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24_cap_enc.vhd
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24_cap_enc.vhd
@@ -76,7 +76,7 @@ package Pintypes is
         (WatchDogTag,   x"00",  ClockLowTag,    x"01",  WatchDogTimeAddr&PadT,      WatchDogNumRegs,    x"00",  WatchDogMPBitMask),
         (IOPortTag,     x"00",  ClockLowTag,    x"03",  PortAddr&PadT,              IOPortNumRegs,      x"00",  IOPortMPBitMask),
         (QcountTag,     x"02",  ClockLowTag,    x"02",  QcounterAddr&PadT,          QCounterNumRegs,    x"00",  QCounterMPBitMask),
-        (StepGenTag,    x"02",  ClockLowTag,    x"0A",  StepGenRateAddr&PadT,       StepGenNumRegs,     x"00",  StepGenMPBitMask),
+        (StepGenTag,    x"02",  ClockLowTag,    x"09",  StepGenRateAddr&PadT,       StepGenNumRegs,     x"00",  StepGenMPBitMask),
         (PWMTag,        x"00",  ClockHighTag,   x"06",  PWMValAddr&PadT,            PWMNumRegs,         x"00",  PWMMPBitMask),
         (LEDTag,        x"00",  ClockLowTag,    x"01",  LEDAddr&PadT,               LEDNumRegs,         x"00",  LEDMPBitMask),
         (NANOADCTag,    x"00",  ClockLowTag,    x"08",  NANOADCAddr&PadT,           NANOADCNumRegs,     x"00",  NANOADCBitMask),

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24_cap_enc.vhd
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24_cap_enc.vhd
@@ -110,81 +110,81 @@ package Pintypes is
     constant PinDesc : PinDescType :=(
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2 DE0-Nano        pin    Function
-        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 00   GPIO_0 01    01        X Step
-        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 01   GPIO_0 02    02        X Dir
-        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 02   GPIO_0 03    03        Y Step
-        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 03   GPIO_0 04    04         Y Dir
-        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 04   GPIO_0 05    05        Z Step
-        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 05   GPIO_0 06    06        Z Dir
-        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 06   GPIO_0 07    07        E0 Step
-        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 07   GPIO_0 08    08        E0 Dir
-        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 08   GPIO_0 09    09        E1 Step
-        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 09   GPIO_0 10    10        E1 Dir
-        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 10   GPIO_0 11    13        E2 Step
-        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 11   GPIO_0 12    14        E2 Dir
-        IOPortTag & x"06" & StepGenTag & StepGenStepPin,    -- I/O 12   GPIO_0 13    15        U Step
-        IOPortTag & x"06" & StepGenTag & StepGenDirPin,     -- I/O 13   GPIO_0 14    16        U Dir
-        IOPortTag & x"07" & StepGenTag & StepGenStepPin,    -- I/O 14   GPIO_0 15    17        V Step
-        IOPortTag & x"07" & StepGenTag & StepGenDirPin,     -- I/O 15   GPIO_0 16    18        V Dir
-        IOPortTag & x"08" & StepGenTag & StepGenStepPin,    -- I/O 16   GPIO_0 17    19        W Step
-        IOPortTag & x"08" & StepGenTag & StepGenDirPin,     -- I/O 17   GPIO_0 18    20        W Dir
-        IOPortTag & x"00" & PWMTag & PWMAOutPin,            -- I/O 18   GPIO_0 19    21        Spindle DAC PWM
-        IOPortTag & x"01" & PWMTag & PWMAOutPin,            -- I/O 19   GPIO_0 20    22        Spindle DAC PWM
-        IOPortTag & x"02" & PWMTag & PWMAOutPin,            -- I/O 20   GPIO_0 21    23        Spindle DAC PWM
-        IOPortTag & x"03" & PWMTag & PWMAOutPin,            -- I/O 21   GPIO_0 22    24        Spindle DAC PWM
-        IOPortTag & x"04" & PWMTag & PWMAOutPin,            -- I/O 22   GPIO_0 23    25        Spindle DAC PWM
-        IOPortTag & x"05" & PWMTag & PWMAOutPin,            -- I/O 23   GPIO_0 24    26        Spindle DAC PWM
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 24   GPIO_0 25    27        Limit X-Min
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 25   GPIO_0 26    28        Limit X-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 26   GPIO_0 27    31        Limit Y-Min
+        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 00   GPIO_0 00    01        X Step
+        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 01   GPIO_0 01    02        X Dir
+        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 02   GPIO_0 02    03        Y Step
+        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 03   GPIO_0 03    04         Y Dir
+        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 04   GPIO_0 04    05        Z Step
+        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 05   GPIO_0 05    06        Z Dir
+        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 06   GPIO_0 06    07        E0 Step
+        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 07   GPIO_0 07    08        E0 Dir
+        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 08   GPIO_0 08    09        E1 Step
+        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 09   GPIO_0 09    10        E1 Dir
+        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 10   GPIO_0 10    13        E2 Step
+        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 11   GPIO_0 11    14        E2 Dir
+        IOPortTag & x"06" & StepGenTag & StepGenStepPin,    -- I/O 12   GPIO_0 12    15        U Step
+        IOPortTag & x"06" & StepGenTag & StepGenDirPin,     -- I/O 13   GPIO_0 13    16        U Dir
+        IOPortTag & x"07" & StepGenTag & StepGenStepPin,    -- I/O 14   GPIO_0 14    17        V Step
+        IOPortTag & x"07" & StepGenTag & StepGenDirPin,     -- I/O 15   GPIO_0 15    18        V Dir
+        IOPortTag & x"08" & StepGenTag & StepGenStepPin,    -- I/O 16   GPIO_0 16    19        W Step
+        IOPortTag & x"08" & StepGenTag & StepGenDirPin,     -- I/O 17   GPIO_0 17    20        W Dir
+        IOPortTag & x"00" & PWMTag & PWMAOutPin,            -- I/O 18   GPIO_0 18    21        Spindle DAC PWM
+        IOPortTag & x"01" & PWMTag & PWMAOutPin,            -- I/O 19   GPIO_0 19    22        Spindle DAC PWM
+        IOPortTag & x"02" & PWMTag & PWMAOutPin,            -- I/O 20   GPIO_0 20    23        Spindle DAC PWM
+        IOPortTag & x"03" & PWMTag & PWMAOutPin,            -- I/O 21   GPIO_0 21    24        Spindle DAC PWM
+        IOPortTag & x"04" & PWMTag & PWMAOutPin,            -- I/O 22   GPIO_0 22    25        Spindle DAC PWM
+        IOPortTag & x"05" & PWMTag & PWMAOutPin,            -- I/O 23   GPIO_0 23    26        Spindle DAC PWM
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 24   GPIO_0 24    27        Limit X-Min
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 25   GPIO_0 25    28        Limit X-Max
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 26   GPIO_0 26    31        Limit Y-Min
         IOPortTag & x"00" & NullTag & NullPin,              -- I/O 27   GPIO_0 27    32        Limit Y-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 28   GPIO_0 29    33        Limit Z-Min
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 29   GPIO_0 30    34        Limit Z-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 30   GPIO_0 31    35        just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 31   GPIO_0 32    36        Led
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 32   GPIO_0 33    37        Axis_ENA_n
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 33   GPIO_0 34    38        Machine_Pwr
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 35    39        Estop (In)
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 36    40        Estop_Sw
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 28   GPIO_0 28    33        Limit Z-Min
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 29   GPIO_0 29    34        Limit Z-Max
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 30   GPIO_0 30    35        just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 31   GPIO_0 31    36        Led
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 32   GPIO_0 32    37        Axis_ENA_n
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 33   GPIO_0 33    38        Machine_Pwr
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 34    39        Estop (In)
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 35    40        Estop_Sw
 
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2    DE0-Nano     pin    Function
-        IOPortTag & x"00" & CAPSENSETag & CapChargePin,     --    I/O 36    GPIO_1 01   01      CapSense charge
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin0,     --    I/O 37    GPIO_1 02   02      CapSense sense 0
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin1,     --    I/O 38    GPIO_1 03   03      CapSense sense 1
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin2,     --    I/O 39    GPIO_1 04   04      CapSense sense 2
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin3,     --    I/O 40    GPIO_1 05   05      CapSense sense 3
-        IOPortTag & x"00" & QCountTag & QCountIdxPin,       --    I/O 41    GPIO_1 06   06      Encoder Z
-        IOPortTag & x"00" & QCountTag & QCountQBPin,        --    I/O 42    GPIO_1 07   07      Encoder B
-        IOPortTag & x"00" & QCountTag & QCountQAPin,        --    I/O 43    GPIO_1 08   08      Encoder A
-        IOPortTag & x"01" & QCountTag & QCountIdxPin,       --    I/O 44    GPIO_1 09   09      Encoder Z
-        IOPortTag & x"01" & QCountTag & QCountQBPin,        --    I/O 45    GPIO_1 10   10      Encoder B
-        IOPortTag & x"01" & QCountTag & QCountQAPin,        --    I/O 46    GPIO_1 11   13      Encoder A
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 47    GPIO_1 12   14      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 48    GPIO_1 13   15      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 49    GPIO_1 14   16      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 50    GPIO_1 15   17      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 51    GPIO_1 16   18      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 52    GPIO_1 17   19      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 53    GPIO_1 18   20      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 54    GPIO_1 19   21      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 55    GPIO_1 20   22      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 56    GPIO_1 21   23      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 57    GPIO_1 22   24      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 58    GPIO_1 23   25      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 59    GPIO_1 24   26      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 60    GPIO_1 25   27      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 61    GPIO_1 26   28      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 62    GPIO_1 27   31      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 63    GPIO_1 28   32      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 64    GPIO_1 29   33      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 65    GPIO_1 30   34      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 66    GPIO_1 31   35      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 67    GPIO_1 32   36      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 68    GPIO_1 33   37      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 69    GPIO_1 34   38      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 70    GPIO_1 35   39      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 71    GPIO_1 36   40      just GPIO
+        IOPortTag & x"00" & CAPSENSETag & CapChargePin,     --    I/O 36    GPIO_1 00   01      CapSense charge
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin0,     --    I/O 37    GPIO_1 01   02      CapSense sense 0
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin1,     --    I/O 38    GPIO_1 02   03      CapSense sense 1
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin2,     --    I/O 39    GPIO_1 03   04      CapSense sense 2
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin3,     --    I/O 40    GPIO_1 04   05      CapSense sense 3
+        IOPortTag & x"00" & QCountTag & QCountIdxPin,       --    I/O 41    GPIO_1 05   06      Encoder Z
+        IOPortTag & x"00" & QCountTag & QCountQBPin,        --    I/O 42    GPIO_1 06   07      Encoder B
+        IOPortTag & x"00" & QCountTag & QCountQAPin,        --    I/O 43    GPIO_1 07   08      Encoder A
+        IOPortTag & x"01" & QCountTag & QCountIdxPin,       --    I/O 44    GPIO_1 08   09      Encoder Z
+        IOPortTag & x"01" & QCountTag & QCountQBPin,        --    I/O 45    GPIO_1 09   10      Encoder B
+        IOPortTag & x"01" & QCountTag & QCountQAPin,        --    I/O 46    GPIO_1 10   13      Encoder A
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 47    GPIO_1 11   14      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 48    GPIO_1 12   15      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 49    GPIO_1 13   16      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 50    GPIO_1 14   17      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 51    GPIO_1 15   18      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 52    GPIO_1 16   19      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 53    GPIO_1 17   20      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 54    GPIO_1 18   21      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 55    GPIO_1 19   22      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 56    GPIO_1 20   23      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 57    GPIO_1 21   24      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 58    GPIO_1 22   25      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 59    GPIO_1 23   26      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 60    GPIO_1 24   27      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 61    GPIO_1 25   28      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 62    GPIO_1 26   31      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 63    GPIO_1 27   32      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 64    GPIO_1 28   33      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 65    GPIO_1 29   34      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 66    GPIO_1 30   35      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 67    GPIO_1 31   36      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 68    GPIO_1 32   37      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 69    GPIO_1 33   38      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 70    GPIO_1 34   39      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 71    GPIO_1 35   40      just GPIO
 
                 -- Remainder of 144 pin descriptors are unused
         emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24_cap_enc_bspi.vhd
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24_cap_enc_bspi.vhd
@@ -110,81 +110,81 @@ package Pintypes is
     constant PinDesc : PinDescType :=(
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2 DE0-Nano        pin    Function
-        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 00   GPIO_0 01    01        X Step
-        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 01   GPIO_0 02    02        X Dir
-        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 02   GPIO_0 03    03        Y Step
-        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 03   GPIO_0 04    04         Y Dir
-        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 04   GPIO_0 05    05        Z Step
-        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 05   GPIO_0 06    06        Z Dir
-        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 06   GPIO_0 07    07        E0 Step
-        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 07   GPIO_0 08    08        E0 Dir
-        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 08   GPIO_0 09    09        E1 Step
-        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 09   GPIO_0 10    10        E1 Dir
-        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 10   GPIO_0 11    13        E2 Step
-        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 11   GPIO_0 12    14        E2 Dir
-        IOPortTag & x"06" & StepGenTag & StepGenStepPin,    -- I/O 12   GPIO_0 13    15        U Step
-        IOPortTag & x"06" & StepGenTag & StepGenDirPin,     -- I/O 13   GPIO_0 14    16        U Dir
-        IOPortTag & x"07" & StepGenTag & StepGenStepPin,    -- I/O 14   GPIO_0 15    17        V Step
-        IOPortTag & x"07" & StepGenTag & StepGenDirPin,     -- I/O 15   GPIO_0 16    18        V Dir
-        IOPortTag & x"08" & StepGenTag & StepGenStepPin,    -- I/O 16   GPIO_0 17    19        W Step
-        IOPortTag & x"08" & StepGenTag & StepGenDirPin,     -- I/O 17   GPIO_0 18    20        W Dir
-        IOPortTag & x"00" & PWMTag & PWMAOutPin,            -- I/O 18   GPIO_0 19    21        Spindle DAC PWM
-        IOPortTag & x"01" & PWMTag & PWMAOutPin,            -- I/O 19   GPIO_0 20    22        Spindle DAC PWM
-        IOPortTag & x"02" & PWMTag & PWMAOutPin,            -- I/O 20   GPIO_0 21    23        Spindle DAC PWM
-        IOPortTag & x"03" & PWMTag & PWMAOutPin,            -- I/O 21   GPIO_0 22    24        Spindle DAC PWM
-        IOPortTag & x"04" & PWMTag & PWMAOutPin,            -- I/O 22   GPIO_0 23    25        Spindle DAC PWM
-        IOPortTag & x"05" & PWMTag & PWMAOutPin,            -- I/O 23   GPIO_0 24    26        Spindle DAC PWM
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 24   GPIO_0 25    27        Limit X-Min
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 25   GPIO_0 26    28        Limit X-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 26   GPIO_0 27    31        Limit Y-Min
+        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 00   GPIO_0 00    01        X Step
+        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 01   GPIO_0 01    02        X Dir
+        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 02   GPIO_0 02    03        Y Step
+        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 03   GPIO_0 03    04         Y Dir
+        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 04   GPIO_0 04    05        Z Step
+        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 05   GPIO_0 05    06        Z Dir
+        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 06   GPIO_0 06    07        E0 Step
+        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 07   GPIO_0 07    08        E0 Dir
+        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 08   GPIO_0 08    09        E1 Step
+        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 09   GPIO_0 08    10        E1 Dir
+        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 10   GPIO_0 10    13        E2 Step
+        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 11   GPIO_0 11    14        E2 Dir
+        IOPortTag & x"06" & StepGenTag & StepGenStepPin,    -- I/O 12   GPIO_0 12    15        U Step
+        IOPortTag & x"06" & StepGenTag & StepGenDirPin,     -- I/O 13   GPIO_0 13    16        U Dir
+        IOPortTag & x"07" & StepGenTag & StepGenStepPin,    -- I/O 14   GPIO_0 14    17        V Step
+        IOPortTag & x"07" & StepGenTag & StepGenDirPin,     -- I/O 15   GPIO_0 15    18        V Dir
+        IOPortTag & x"08" & StepGenTag & StepGenStepPin,    -- I/O 16   GPIO_0 16    19        W Step
+        IOPortTag & x"08" & StepGenTag & StepGenDirPin,     -- I/O 17   GPIO_0 17    20        W Dir
+        IOPortTag & x"00" & PWMTag & PWMAOutPin,            -- I/O 18   GPIO_0 18    21        Spindle DAC PWM
+        IOPortTag & x"01" & PWMTag & PWMAOutPin,            -- I/O 19   GPIO_0 19    22        Spindle DAC PWM
+        IOPortTag & x"02" & PWMTag & PWMAOutPin,            -- I/O 20   GPIO_0 20    23        Spindle DAC PWM
+        IOPortTag & x"03" & PWMTag & PWMAOutPin,            -- I/O 21   GPIO_0 21    24        Spindle DAC PWM
+        IOPortTag & x"04" & PWMTag & PWMAOutPin,            -- I/O 22   GPIO_0 22    25        Spindle DAC PWM
+        IOPortTag & x"05" & PWMTag & PWMAOutPin,            -- I/O 23   GPIO_0 23    26        Spindle DAC PWM
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 24   GPIO_0 24    27        Limit X-Min
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 25   GPIO_0 25    28        Limit X-Max
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 26   GPIO_0 26    31        Limit Y-Min
         IOPortTag & x"00" & NullTag & NullPin,              -- I/O 27   GPIO_0 27    32        Limit Y-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 28   GPIO_0 29    33        Limit Z-Min
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 29   GPIO_0 30    34        Limit Z-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 30   GPIO_0 31    35        just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 31   GPIO_0 32    36        Led
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 32   GPIO_0 33    37        Axis_ENA_n
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 33   GPIO_0 34    38        Machine_Pwr
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 35    39        Estop (In)
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 36    40        Estop_Sw
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 28   GPIO_0 28    33        Limit Z-Min
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 29   GPIO_0 29    34        Limit Z-Max
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 30   GPIO_0 30    35        just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 31   GPIO_0 31    36        Led
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 32   GPIO_0 32    37        Axis_ENA_n
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 33   GPIO_0 33    38        Machine_Pwr
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 34    39        Estop (In)
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 35    40        Estop_Sw
 
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2    DE0-Nano     pin    Function
-        IOPortTag & x"00" & CAPSENSETag & CapChargePin,     --    I/O 36    GPIO_1 01   01      CapSense charge
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin0,     --    I/O 37    GPIO_1 02   02      CapSense sense 0
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin1,     --    I/O 38    GPIO_1 03   03      CapSense sense 1
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin2,     --    I/O 39    GPIO_1 04   04      CapSense sense 2
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin3,     --    I/O 40    GPIO_1 05   05      CapSense sense 3
-        IOPortTag & x"00" & QCountTag & QCountIdxPin,       --    I/O 41    GPIO_1 06   06      Encoder Z
-        IOPortTag & x"00" & QCountTag & QCountQBPin,        --    I/O 42    GPIO_1 07   07      Encoder B
-        IOPortTag & x"00" & QCountTag & QCountQAPin,        --    I/O 43    GPIO_1 08   08      Encoder A
-        IOPortTag & x"01" & QCountTag & QCountIdxPin,       --    I/O 44    GPIO_1 09   09      Encoder Z
-        IOPortTag & x"01" & QCountTag & QCountQBPin,        --    I/O 45    GPIO_1 10   10      Encoder B
-        IOPortTag & x"01" & QCountTag & QCountQAPin,        --    I/O 46    GPIO_1 11   13      Encoder A
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 47    GPIO_1 12   14      just GPIO
-        IOPortTag & x"00" & BSPITag & BSPIFramePin,         --    I/O 48    GPIO_1 13   15      SPI Frame
-        IOPortTag & x"00" & BSPITag & BSPIOutPin,           --    I/O 49    GPIO_1 14   16      SPI Out
-        IOPortTag & x"00" & BSPITag & BSPIClkPin,           --    I/O 50    GPIO_1 15   17      SPI Clk
-        IOPortTag & x"00" & BSPITag & BSPIInPin,            --    I/O 51    GPIO_1 16   18      SPI In
-        IOPortTag & x"00" & BSPITag & BSPICS2Pin,           --    I/O 52    GPIO_1 17   19      SPI Cs
-        IOPortTag & x"00" & BSPITag & BSPICS1Pin,           --    I/O 53    GPIO_1 18   20      SPI Cs
-        IOPortTag & x"00" & BSPITag & BSPICS0Pin,           --    I/O 54    GPIO_1 19   21      SPI Cs
-        IOPortTag & x"01" & BSPITag & BSPIFramePin,         --    I/O 55    GPIO_1 20   22      SPI Frame
-        IOPortTag & x"01" & BSPITag & BSPIOutPin,           --    I/O 56    GPIO_1 21   23      SPI Out
-        IOPortTag & x"01" & BSPITag & BSPIClkPin,           --    I/O 57    GPIO_1 22   24      SPI Clk
-        IOPortTag & x"01" & BSPITag & BSPIInPin,            --    I/O 58    GPIO_1 23   25      SPI In
-        IOPortTag & x"01" & BSPITag & BSPICS2Pin,           --    I/O 59    GPIO_1 24   26      SPI Cs
-        IOPortTag & x"01" & BSPITag & BSPICS1Pin,           --    I/O 60    GPIO_1 25   27      SPI Cs
-        IOPortTag & x"01" & BSPITag & BSPICS0Pin,           --    I/O 61    GPIO_1 26   28      SPI Cs
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 62    GPIO_1 27   31      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 63    GPIO_1 28   32      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 64    GPIO_1 29   33      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 65    GPIO_1 30   34      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 66    GPIO_1 31   35      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 67    GPIO_1 32   36      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 68    GPIO_1 33   37      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 69    GPIO_1 34   38      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 70    GPIO_1 35   39      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 71    GPIO_1 36   40      just GPIO
+        IOPortTag & x"00" & CAPSENSETag & CapChargePin,     --    I/O 36    GPIO_1 00   01      CapSense charge
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin0,     --    I/O 37    GPIO_1 01   02      CapSense sense 0
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin1,     --    I/O 38    GPIO_1 02   03      CapSense sense 1
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin2,     --    I/O 39    GPIO_1 03   04      CapSense sense 2
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin3,     --    I/O 40    GPIO_1 04   05      CapSense sense 3
+        IOPortTag & x"00" & QCountTag & QCountIdxPin,       --    I/O 41    GPIO_1 05   06      Encoder Z
+        IOPortTag & x"00" & QCountTag & QCountQBPin,        --    I/O 42    GPIO_1 06   07      Encoder B
+        IOPortTag & x"00" & QCountTag & QCountQAPin,        --    I/O 43    GPIO_1 07   08      Encoder A
+        IOPortTag & x"01" & QCountTag & QCountIdxPin,       --    I/O 44    GPIO_1 08   09      Encoder Z
+        IOPortTag & x"01" & QCountTag & QCountQBPin,        --    I/O 45    GPIO_1 09   10      Encoder B
+        IOPortTag & x"01" & QCountTag & QCountQAPin,        --    I/O 46    GPIO_1 10   13      Encoder A
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 47    GPIO_1 11   14      just GPIO
+        IOPortTag & x"00" & BSPITag & BSPIFramePin,         --    I/O 48    GPIO_1 12   15      SPI Frame
+        IOPortTag & x"00" & BSPITag & BSPIOutPin,           --    I/O 49    GPIO_1 13   16      SPI Out
+        IOPortTag & x"00" & BSPITag & BSPIClkPin,           --    I/O 50    GPIO_1 14   17      SPI Clk
+        IOPortTag & x"00" & BSPITag & BSPIInPin,            --    I/O 51    GPIO_1 15   18      SPI In
+        IOPortTag & x"00" & BSPITag & BSPICS2Pin,           --    I/O 52    GPIO_1 16   19      SPI Cs
+        IOPortTag & x"00" & BSPITag & BSPICS1Pin,           --    I/O 53    GPIO_1 17   20      SPI Cs
+        IOPortTag & x"00" & BSPITag & BSPICS0Pin,           --    I/O 54    GPIO_1 18   21      SPI Cs
+        IOPortTag & x"01" & BSPITag & BSPIFramePin,         --    I/O 55    GPIO_1 19   22      SPI Frame
+        IOPortTag & x"01" & BSPITag & BSPIOutPin,           --    I/O 56    GPIO_1 20   23      SPI Out
+        IOPortTag & x"01" & BSPITag & BSPIClkPin,           --    I/O 57    GPIO_1 21   24      SPI Clk
+        IOPortTag & x"01" & BSPITag & BSPIInPin,            --    I/O 58    GPIO_1 22   25      SPI In
+        IOPortTag & x"01" & BSPITag & BSPICS2Pin,           --    I/O 59    GPIO_1 23   26      SPI Cs
+        IOPortTag & x"01" & BSPITag & BSPICS1Pin,           --    I/O 60    GPIO_1 24   27      SPI Cs
+        IOPortTag & x"01" & BSPITag & BSPICS0Pin,           --    I/O 61    GPIO_1 25   28      SPI Cs
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 62    GPIO_1 26   31      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 63    GPIO_1 27   32      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 64    GPIO_1 28   33      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 65    GPIO_1 29   34      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 66    GPIO_1 30   35      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 67    GPIO_1 31   36      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 68    GPIO_1 32   37      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 69    GPIO_1 33   38      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 70    GPIO_1 34   39      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 71    GPIO_1 35   40      just GPIO
 
                 -- Remainder of 144 pin descriptors are unused
         emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24_cap_enc_dbspi.vhd
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_3x24_cap_enc_dbspi.vhd
@@ -110,81 +110,81 @@ package Pintypes is
     constant PinDesc : PinDescType :=(
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2 DE0-Nano        pin    Function
-        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 00   GPIO_0 01    01        X Step
-        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 01   GPIO_0 02    02        X Dir
-        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 02   GPIO_0 03    03        Y Step
-        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 03   GPIO_0 04    04         Y Dir
-        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 04   GPIO_0 05    05        Z Step
-        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 05   GPIO_0 06    06        Z Dir
-        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 06   GPIO_0 07    07        E0 Step
-        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 07   GPIO_0 08    08        E0 Dir
-        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 08   GPIO_0 09    09        E1 Step
-        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 09   GPIO_0 10    10        E1 Dir
-        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 10   GPIO_0 11    13        E2 Step
-        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 11   GPIO_0 12    14        E2 Dir
-        IOPortTag & x"06" & StepGenTag & StepGenStepPin,    -- I/O 12   GPIO_0 13    15        U Step
-        IOPortTag & x"06" & StepGenTag & StepGenDirPin,     -- I/O 13   GPIO_0 14    16        U Dir
-        IOPortTag & x"07" & StepGenTag & StepGenStepPin,    -- I/O 14   GPIO_0 15    17        V Step
-        IOPortTag & x"07" & StepGenTag & StepGenDirPin,     -- I/O 15   GPIO_0 16    18        V Dir
-        IOPortTag & x"08" & StepGenTag & StepGenStepPin,    -- I/O 16   GPIO_0 17    19        W Step
-        IOPortTag & x"08" & StepGenTag & StepGenDirPin,     -- I/O 17   GPIO_0 18    20        W Dir
-        IOPortTag & x"00" & PWMTag & PWMAOutPin,            -- I/O 18   GPIO_0 19    21        Spindle DAC PWM
-        IOPortTag & x"01" & PWMTag & PWMAOutPin,            -- I/O 19   GPIO_0 20    22        Spindle DAC PWM
-        IOPortTag & x"02" & PWMTag & PWMAOutPin,            -- I/O 20   GPIO_0 21    23        Spindle DAC PWM
-        IOPortTag & x"03" & PWMTag & PWMAOutPin,            -- I/O 21   GPIO_0 22    24        Spindle DAC PWM
-        IOPortTag & x"04" & PWMTag & PWMAOutPin,            -- I/O 22   GPIO_0 23    25        Spindle DAC PWM
-        IOPortTag & x"05" & PWMTag & PWMAOutPin,            -- I/O 23   GPIO_0 24    26        Spindle DAC PWM
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 24   GPIO_0 25    27        Limit X-Min
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 25   GPIO_0 26    28        Limit X-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 26   GPIO_0 27    31        Limit Y-Min
+        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 00   GPIO_0 00    01        X Step
+        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 01   GPIO_0 01    02        X Dir
+        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 02   GPIO_0 02    03        Y Step
+        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 03   GPIO_0 03    04         Y Dir
+        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 04   GPIO_0 04    05        Z Step
+        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 05   GPIO_0 05    06        Z Dir
+        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 06   GPIO_0 06    07        E0 Step
+        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 07   GPIO_0 07    08        E0 Dir
+        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 08   GPIO_0 08    09        E1 Step
+        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 09   GPIO_0 09    10        E1 Dir
+        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 10   GPIO_0 10    13        E2 Step
+        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 11   GPIO_0 11    14        E2 Dir
+        IOPortTag & x"06" & StepGenTag & StepGenStepPin,    -- I/O 12   GPIO_0 12    15        U Step
+        IOPortTag & x"06" & StepGenTag & StepGenDirPin,     -- I/O 13   GPIO_0 13    16        U Dir
+        IOPortTag & x"07" & StepGenTag & StepGenStepPin,    -- I/O 14   GPIO_0 14    17        V Step
+        IOPortTag & x"07" & StepGenTag & StepGenDirPin,     -- I/O 15   GPIO_0 15    18        V Dir
+        IOPortTag & x"08" & StepGenTag & StepGenStepPin,    -- I/O 16   GPIO_0 16    19        W Step
+        IOPortTag & x"08" & StepGenTag & StepGenDirPin,     -- I/O 17   GPIO_0 17    20        W Dir
+        IOPortTag & x"00" & PWMTag & PWMAOutPin,            -- I/O 18   GPIO_0 18    21        Spindle DAC PWM
+        IOPortTag & x"01" & PWMTag & PWMAOutPin,            -- I/O 19   GPIO_0 19    22        Spindle DAC PWM
+        IOPortTag & x"02" & PWMTag & PWMAOutPin,            -- I/O 20   GPIO_0 20    23        Spindle DAC PWM
+        IOPortTag & x"03" & PWMTag & PWMAOutPin,            -- I/O 21   GPIO_0 21    24        Spindle DAC PWM
+        IOPortTag & x"04" & PWMTag & PWMAOutPin,            -- I/O 22   GPIO_0 22    25        Spindle DAC PWM
+        IOPortTag & x"05" & PWMTag & PWMAOutPin,            -- I/O 23   GPIO_0 23    26        Spindle DAC PWM
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 24   GPIO_0 24    27        Limit X-Min
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 25   GPIO_0 25    28        Limit X-Max
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 26   GPIO_0 26    31        Limit Y-Min
         IOPortTag & x"00" & NullTag & NullPin,              -- I/O 27   GPIO_0 27    32        Limit Y-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 28   GPIO_0 29    33        Limit Z-Min
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 29   GPIO_0 30    34        Limit Z-Max
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 30   GPIO_0 31    35        just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 31   GPIO_0 32    36        Led
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 32   GPIO_0 33    37        Axis_ENA_n
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 33   GPIO_0 34    38        Machine_Pwr
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 35    39        Estop (In)
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 36    40        Estop_Sw
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 28   GPIO_0 28    33        Limit Z-Min
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 29   GPIO_0 29    34        Limit Z-Max
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 30   GPIO_0 30    35        just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 31   GPIO_0 31    36        Led
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 32   GPIO_0 32    37        Axis_ENA_n
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 33   GPIO_0 33    38        Machine_Pwr
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 34    39        Estop (In)
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 35    40        Estop_Sw
 
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2    DE0-Nano     pin    Function
-        IOPortTag & x"00" & CAPSENSETag & CapChargePin,     --    I/O 36    GPIO_1 01   01      CapSense charge
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin0,     --    I/O 37    GPIO_1 02   02      CapSense sense 0
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin1,     --    I/O 38    GPIO_1 03   03      CapSense sense 1
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin2,     --    I/O 39    GPIO_1 04   04      CapSense sense 2
-        IOPortTag & x"00" & CAPSENSETag & CapSensePin3,     --    I/O 40    GPIO_1 05   05      CapSense sense 3
-        IOPortTag & x"00" & QCountTag & QCountIdxPin,       --    I/O 41    GPIO_1 06   06      Encoder Z
-        IOPortTag & x"00" & QCountTag & QCountQBPin,        --    I/O 42    GPIO_1 07   07      Encoder B
-        IOPortTag & x"00" & QCountTag & QCountQAPin,        --    I/O 43    GPIO_1 08   08      Encoder A
-        IOPortTag & x"01" & QCountTag & QCountIdxPin,       --    I/O 44    GPIO_1 09   09      Encoder Z
-        IOPortTag & x"01" & QCountTag & QCountQBPin,        --    I/O 45    GPIO_1 10   10      Encoder B
-        IOPortTag & x"01" & QCountTag & QCountQAPin,        --    I/O 46    GPIO_1 11   13      Encoder A
-        IOPortTag & x"00" & DBSPITag & DBSPIOutPin,         --    I/O 47    GPIO_1 12   14      SPI Out
-        IOPortTag & x"00" & DBSPITag & DBSPIClkPin,         --    I/O 48    GPIO_1 13   15      SPI Clk
-        IOPortTag & x"00" & DBSPITag & DBSPIInPin,          --    I/O 49    GPIO_1 14   16      SPI In
-        IOPortTag & x"00" & DBSPITag & DBSPICS0Pin,         --    I/O 50    GPIO_1 15   17      SPI Cs
-        IOPortTag & x"00" & DBSPITag & DBSPICS1Pin,         --    I/O 51    GPIO_1 16   18      SPI Cs
-        IOPortTag & x"00" & DBSPITag & DBSPICS2Pin,         --    I/O 52    GPIO_1 17   19      SPI Cs
-        IOPortTag & x"00" & DBSPITag & DBSPICS3Pin,         --    I/O 53    GPIO_1 18   20      SPI Cs
-        IOPortTag & x"00" & DBSPITag & DBSPICS4Pin,         --    I/O 54    GPIO_1 19   21      SPI Cs
-        IOPortTag & x"00" & DBSPITag & DBSPICS5Pin,         --    I/O 55    GPIO_1 20   22      SPI Cs
-        IOPortTag & x"00" & DBSPITag & DBSPICS6Pin,         --    I/O 56    GPIO_1 21   23      SPI Cs
-        IOPortTag & x"00" & DBSPITag & DBSPICS7Pin,         --    I/O 57    GPIO_1 22   24      SPI Cs
-        IOPortTag & x"01" & NullTag & NullPin,              --    I/O 58    GPIO_1 23   25      just GPIO
-        IOPortTag & x"01" & NullTag & NullPin,              --    I/O 59    GPIO_1 24   26      just GPIO
-        IOPortTag & x"01" & NullTag & NullPin,              --    I/O 60    GPIO_1 25   27      just GPIO
-        IOPortTag & x"01" & NullTag & NullPin,              --    I/O 61    GPIO_1 26   28      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 62    GPIO_1 27   31      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 63    GPIO_1 28   32      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 64    GPIO_1 29   33      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 65    GPIO_1 30   34      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 66    GPIO_1 31   35      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 67    GPIO_1 32   36      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 68    GPIO_1 33   37      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 69    GPIO_1 34   38      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 70    GPIO_1 35   39      just GPIO
-        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 71    GPIO_1 36   40      just GPIO
+        IOPortTag & x"00" & CAPSENSETag & CapChargePin,     --    I/O 36    GPIO_1 00   01      CapSense charge
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin0,     --    I/O 37    GPIO_1 01   02      CapSense sense 0
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin1,     --    I/O 38    GPIO_1 02   03      CapSense sense 1
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin2,     --    I/O 39    GPIO_1 03   04      CapSense sense 2
+        IOPortTag & x"00" & CAPSENSETag & CapSensePin3,     --    I/O 40    GPIO_1 04   05      CapSense sense 3
+        IOPortTag & x"00" & QCountTag & QCountIdxPin,       --    I/O 41    GPIO_1 05   06      Encoder Z
+        IOPortTag & x"00" & QCountTag & QCountQBPin,        --    I/O 42    GPIO_1 06   07      Encoder B
+        IOPortTag & x"00" & QCountTag & QCountQAPin,        --    I/O 43    GPIO_1 07   08      Encoder A
+        IOPortTag & x"01" & QCountTag & QCountIdxPin,       --    I/O 44    GPIO_1 08   09      Encoder Z
+        IOPortTag & x"01" & QCountTag & QCountQBPin,        --    I/O 45    GPIO_1 09   10      Encoder B
+        IOPortTag & x"01" & QCountTag & QCountQAPin,        --    I/O 46    GPIO_1 10   13      Encoder A
+        IOPortTag & x"00" & DBSPITag & DBSPIOutPin,         --    I/O 47    GPIO_1 11   14      SPI Out
+        IOPortTag & x"00" & DBSPITag & DBSPIClkPin,         --    I/O 48    GPIO_1 12   15      SPI Clk
+        IOPortTag & x"00" & DBSPITag & DBSPIInPin,          --    I/O 49    GPIO_1 13   16      SPI In
+        IOPortTag & x"00" & DBSPITag & DBSPICS0Pin,         --    I/O 50    GPIO_1 14   17      SPI Cs
+        IOPortTag & x"00" & DBSPITag & DBSPICS1Pin,         --    I/O 51    GPIO_1 15   18      SPI Cs
+        IOPortTag & x"00" & DBSPITag & DBSPICS2Pin,         --    I/O 52    GPIO_1 16   19      SPI Cs
+        IOPortTag & x"00" & DBSPITag & DBSPICS3Pin,         --    I/O 53    GPIO_1 17   20      SPI Cs
+        IOPortTag & x"00" & DBSPITag & DBSPICS4Pin,         --    I/O 54    GPIO_1 18   21      SPI Cs
+        IOPortTag & x"00" & DBSPITag & DBSPICS5Pin,         --    I/O 55    GPIO_1 19   22      SPI Cs
+        IOPortTag & x"00" & DBSPITag & DBSPICS6Pin,         --    I/O 56    GPIO_1 20   23      SPI Cs
+        IOPortTag & x"00" & DBSPITag & DBSPICS7Pin,         --    I/O 57    GPIO_1 21   24      SPI Cs
+        IOPortTag & x"01" & NullTag & NullPin,              --    I/O 58    GPIO_1 22   25      just GPIO
+        IOPortTag & x"01" & NullTag & NullPin,              --    I/O 59    GPIO_1 23   26      just GPIO
+        IOPortTag & x"01" & NullTag & NullPin,              --    I/O 60    GPIO_1 24   27      just GPIO
+        IOPortTag & x"01" & NullTag & NullPin,              --    I/O 61    GPIO_1 25   28      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 62    GPIO_1 26   31      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 63    GPIO_1 27   32      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 64    GPIO_1 28   33      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 65    GPIO_1 29   34      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 66    GPIO_1 30   35      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 67    GPIO_1 31   36      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 68    GPIO_1 32   37      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 69    GPIO_1 33   38      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 70    GPIO_1 34   39      just GPIO
+        IOPortTag & x"00" & NullTag & NullPin,              --    I/O 71    GPIO_1 35   40      just GPIO
 
                 -- Remainder of 144 pin descriptors are unused
         emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_st_fpga_soc_dc1f_ss.vhd
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_st_fpga_soc_dc1f_ss.vhd
@@ -110,7 +110,7 @@ package Pintypes is
     constant PinDesc : PinDescType :=(
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2 DE0-Nano     pin      Function
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 00   GPIO_0 20    01        GP_Input_01 
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 00   GPIO_0 20    01        GP_Input_01
         IOPortTag & x"00" & NullTag & NullPin,              -- I/O 01   GPIO_0 20    02        GP_Input_00
         IOPortTag & x"00" & NullTag & NullPin,              -- I/O 02   GPIO_0 21    03        GP_Input_03
         IOPortTag & x"00" & NullTag & NullPin,              -- I/O 03   GPIO_0 22    04        GP_Input_02
@@ -149,43 +149,43 @@ package Pintypes is
 
 --      Base       Sec      Sec       Sec
 --      func       unit     func      pin                   -- hostmot2  DE0-Nano    pin    Function
-        IOPortTag & x"00" & SSerialTag & SSerialTX0Pin,     -- I/O 36    GPIO_1 01   01      rs_422_Tx_0 
-        IOPortTag & x"00" & SSerialTag & SSerialRX0Pin,     -- I/O 37    GPIO_1 02   02      rs_422_Rx_0        
-        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 38    GPIO_1 03   03      Step_5
-        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 39    GPIO_1 04   04      Dir_5
-        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 40    GPIO_1 05   05      Step_4
-        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 41    GPIO_1 06   06      Dir_4
-        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 42    GPIO_1 07   07      Step_3
-        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 43    GPIO_1 08   08      Dir_3
-        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 44    GPIO_1 09   09      Step_2
-        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 45    GPIO_1 10   10      Dir_2
-        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 46    GPIO_1 11   13      Step_1
-        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 47    GPIO_1 12   14      Dir_1
-        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 48    GPIO_1 13   15      Step_0
-        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 49    GPIO_1 14   16      Dir_0
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 50    GPIO_1 15   17      Step4_Enable
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 51    GPIO_1 16   18      Step5_Enable
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 52    GPIO_1 17   19      Step2_Enable
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 53    GPIO_1 18   20      Step3_Enable
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 54    GPIO_1 19   21      Step0_Enable
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 55    GPIO_1 20   22      Step1_Enable
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 56    GPIO_1 21   23      GP_Output_00
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 57    GPIO_1 22   24      GP_Output_08
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 58    GPIO_1 23   25      GP_Output_01
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 59    GPIO_1 24   26      GP_Output_09
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 60    GPIO_1 25   27      GP_Output_02
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 61    GPIO_1 26   28      GP_Output_10
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 62    GPIO_1 27   31      GP_Output_03
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 63    GPIO_1 28   32      GP_Output_11
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 64    GPIO_1 29   33      GP_Output_04
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 65    GPIO_1 30   34      GP_Output_12
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 66    GPIO_1 31   35      GP_Output_05
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 67    GPIO_1 32   36      GP_Output_13
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 68    GPIO_1 33   37      GP_Output_06
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 69    GPIO_1 34   38      GP_Output_14
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 70    GPIO_1 35   39      GP_Output_07
-        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 71    GPIO_1 36   40      GP_Output_15
-      
+        IOPortTag & x"00" & SSerialTag & SSerialTX0Pin,     -- I/O 36    GPIO_1 00   01      rs_422_Tx_0
+        IOPortTag & x"00" & SSerialTag & SSerialRX0Pin,     -- I/O 37    GPIO_1 01   02      rs_422_Rx_0
+        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 38    GPIO_1 02   03      Step_5
+        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 39    GPIO_1 03   04      Dir_5
+        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 40    GPIO_1 04   05      Step_4
+        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 41    GPIO_1 05   06      Dir_4
+        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 42    GPIO_1 06   07      Step_3
+        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 43    GPIO_1 07   08      Dir_3
+        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 44    GPIO_1 08   09      Step_2
+        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 45    GPIO_1 09   10      Dir_2
+        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 46    GPIO_1 10   13      Step_1
+        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 47    GPIO_1 11   14      Dir_1
+        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 48    GPIO_1 12   15      Step_0
+        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 49    GPIO_1 13   16      Dir_0
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 50    GPIO_1 14   17      Step4_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 51    GPIO_1 15   18      Step5_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 52    GPIO_1 16   19      Step2_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 53    GPIO_1 17   20      Step3_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 54    GPIO_1 18   21      Step0_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 55    GPIO_1 19   22      Step1_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 56    GPIO_1 20   23      GP_Output_00
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 57    GPIO_1 21   24      GP_Output_08
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 58    GPIO_1 22   25      GP_Output_01
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 59    GPIO_1 23   26      GP_Output_09
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 60    GPIO_1 24   27      GP_Output_02
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 61    GPIO_1 25   28      GP_Output_10
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 62    GPIO_1 26   31      GP_Output_03
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 63    GPIO_1 27   32      GP_Output_11
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 64    GPIO_1 28   33      GP_Output_04
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 65    GPIO_1 29   34      GP_Output_12
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 66    GPIO_1 30   35      GP_Output_05
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 67    GPIO_1 31   36      GP_Output_13
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 68    GPIO_1 32   37      GP_Output_06
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 69    GPIO_1 33   38      GP_Output_14
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 70    GPIO_1 34   39      GP_Output_07
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 71    GPIO_1 35   40      GP_Output_15
+
           -- Remainder of 144 pin descriptors are unused
         emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
         emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_st_fpga_soc_dc1f_ss.vhd
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/PIN_st_fpga_soc_dc1f_ss.vhd
@@ -1,0 +1,200 @@
+library IEEE;
+use IEEE.std_logic_1164.all;  -- defines std_logic types
+use IEEE.STD_LOGIC_ARITH.ALL;
+use IEEE.STD_LOGIC_UNSIGNED.ALL;
+
+-- Copyright (C) 2007, Peter C. Wallace, Mesa Electronics
+-- http://www.mesanet.com
+--
+-- This program is is licensed under a disjunctive dual license giving you
+-- the choice of one of the two following sets of free software/open source
+-- licensing terms:
+--
+--    * GNU General Public License (GPL), version 2.0 or later
+--    * 3-clause BSD License
+--
+--
+-- The GNU GPL License:
+--
+--     This program is free software; you can redistribute it and/or modify
+--     it under the terms of the GNU General Public License as published by
+--     the Free Software Foundation; either version 2 of the License, or
+--     (at your option) any later version.
+--
+--     This program is distributed in the hope that it will be useful,
+--     but WITHOUT ANY WARRANTY; without even the implied warranty of
+--     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--     GNU General Public License for more details.
+--
+--     You should have received a copy of the GNU General Public License
+--     along with this program; if not, write to the Free Software
+--     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+--
+--
+-- The 3-clause BSD License:
+--
+--     Redistribution and use in source and binary forms, with or without
+--     modification, are permitted provided that the following conditions
+--     are met:
+--
+--   * Redistributions of source code must retain the above copyright
+--     notice, this list of conditions and the following disclaimer.
+--
+--   * Redistributions in binary form must reproduce the above
+--     copyright notice, this list of conditions and the following
+--     disclaimer in the documentation and/or other materials
+--     provided with the distribution.
+--
+--   * Neither the name of Mesa Electronics nor the names of its
+--     contributors may be used to endorse or promote products
+--     derived from this software without specific prior written
+--     permission.
+--
+--
+-- Disclaimer:
+--
+--     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+--     "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+--     LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+--     FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+--     COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+--     INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+--     BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+--     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+--     LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+--     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+--     POSSIBILITY OF SUCH DAMAGE.
+--
+
+use work.IDROMConst.all;
+
+package Pintypes is
+    constant ModuleID : ModuleIDType :=(
+    -- GTag             Version Clock           NumInst BaseAddr                    NumRegisters        Strides MultiRegs
+        (HM2DPLLTag,    x"00",  ClockLowTag,    x"01",  HM2DPLLBaseRateAddr&PadT,   HM2DPLLNumRegs,     x"00",  HM2DPLLMPBitMask),
+        (WatchDogTag,   x"00",  ClockLowTag,    x"01",  WatchDogTimeAddr&PadT,      WatchDogNumRegs,    x"00",  WatchDogMPBitMask),
+        (IOPortTag,     x"00",  ClockLowTag,    x"03",  PortAddr&PadT,              IOPortNumRegs,      x"00",  IOPortMPBitMask),
+        (QcountTag,     x"02",  ClockLowTag,    x"06",  QcounterAddr&PadT,          QCounterNumRegs,    x"00",  QCounterMPBitMask),
+        (StepGenTag,    x"02",  ClockLowTag,    x"06",  StepGenRateAddr&PadT,       StepGenNumRegs,     x"00",  StepGenMPBitMask),
+        (SSerialTag,    x"00",  ClockLowTag,    x"01",  SSerialCommandAddr&PadT,    SSerialNumRegs,     x"10",  SSerialMPBitMask),
+        (PWMTag,        x"00",  ClockHighTag,   x"00",  PWMValAddr&PadT,            PWMNumRegs,         x"00",  PWMMPBitMask),
+        (LEDTag,        x"00",  ClockLowTag,    x"01",  LEDAddr&PadT,               LEDNumRegs,         x"00",  LEDMPBitMask),
+        (NANOADCTag,    x"00",  ClockLowTag,    x"08",  NANOADCAddr&PadT,           NANOADCNumRegs,     x"00",  NANOADCBitMask),
+        (FWIDTag,       x"00",  ClockLowTag,    x"01",  FWIDAddr&PadT,              FWIDNumRegs,        x"00",  FWIDMPBitMask),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000"),
+        (NullTag,       x"00",  NullTag,        x"00",  NullAddr&PadT,              x"00",              x"00",  x"00000000")
+        );
+
+
+    constant PinDesc : PinDescType :=(
+--      Base       Sec      Sec       Sec
+--      func       unit     func      pin                   -- hostmot2 DE0-Nano     pin      Function
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 00   GPIO_0 20    01        GP_Input_01 
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 01   GPIO_0 20    02        GP_Input_00
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 02   GPIO_0 21    03        GP_Input_03
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 03   GPIO_0 22    04        GP_Input_02
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 04   GPIO_0 23    05        GP_Input_05
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 05   GPIO_0 24    06        GP_Input_04
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 06   GPIO_0 25    07        GP_Input_07
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 07   GPIO_0 26    08        GP_Input_06
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 08   GPIO_0 27    09        GP_Input_09
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 09   GPIO_0 28    10        GP_Input_08
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 10   GPIO_0 29    13        GP_Input_11
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 11   GPIO_0 30    14        GP_Input_10
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 12   GPIO_0 31    15        GP_Input_13
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 13   GPIO_0 32    16        GP_Input_12
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 14   GPIO_0 33    17        GP_Input_15
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 15   GPIO_0 34    18        GP_Input_14
+        IOPortTag & x"01" & QCountTag & QCountIdxPin,       -- I/O 16   GPIO_0 01    19        Enc1 Z
+        IOPortTag & x"00" & QCountTag & QCountIdxPin,       -- I/O 17   GPIO_0 02    20        Enc0 Z
+        IOPortTag & x"00" & QCountTag & QCountQAPin,        -- I/O 18   GPIO_0 03    21        Enc0 A
+        IOPortTag & x"02" & QCountTag & QCountIdxPin,       -- I/O 19   GPIO_0 04    22        Enc2 Z
+        IOPortTag & x"02" & QCountTag & QCountQAPin,        -- I/O 20   GPIO_0 05    23        Enc2 A
+        IOPortTag & x"01" & QCountTag & QCountQAPin,        -- I/O 21   GPIO_0 06    24        Enc1 A
+        IOPortTag & x"01" & QCountTag & QCountQBPin,        -- I/O 22   GPIO_0 07    25        Enc1 B
+        IOPortTag & x"00" & QCountTag & QCountQBPin,        -- I/O 23   GPIO_0 08    26        Enc0 B
+        IOPortTag & x"03" & QCountTag & QCountIdxPin,       -- I/O 24   GPIO_0 09    27        Enc3 Z
+        IOPortTag & x"02" & QCountTag & QCountQBPin,        -- I/O 25   GPIO_0 10    28        Enc2 B
+        IOPortTag & x"05" & QCountTag & QCountIdxPin,       -- I/O 26   GPIO_0 11    31        Enc5 Z
+        IOPortTag & x"04" & QCountTag & QCountIdxPin,       -- I/O 27   GPIO_0 12    32        Enc4 Z
+        IOPortTag & x"04" & QCountTag & QCountQAPin,        -- I/O 28   GPIO_0 13    33        Enc4 A
+        IOPortTag & x"03" & QCountTag & QCountQAPin,        -- I/O 29   GPIO_0 14    34        Enc3 A
+        IOPortTag & x"03" & QCountTag & QCountQBPin,        -- I/O 30   GPIO_0 15    35        Enc3 B
+        IOPortTag & x"05" & QCountTag & QCountQAPin,        -- I/O 31   GPIO_0 16    36        Enc5 A
+        IOPortTag & x"05" & QCountTag & QCountQBPin,        -- I/O 32   GPIO_0 17    37        Enc5 B
+        IOPortTag & x"04" & QCountTag & QCountQBPin,        -- I/O 33   GPIO_0 18    38        Enc4 B
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 34   GPIO_0 35    39        GP_Output_HC_17
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 35   GPIO_0 36    40        GP_Output_HC_16
+
+--      Base       Sec      Sec       Sec
+--      func       unit     func      pin                   -- hostmot2  DE0-Nano    pin    Function
+        IOPortTag & x"00" & SSerialTag & SSerialTX0Pin,     -- I/O 36    GPIO_1 01   01      rs_422_Tx_0 
+        IOPortTag & x"00" & SSerialTag & SSerialRX0Pin,     -- I/O 37    GPIO_1 02   02      rs_422_Rx_0        
+        IOPortTag & x"05" & StepGenTag & StepGenStepPin,    -- I/O 38    GPIO_1 03   03      Step_5
+        IOPortTag & x"05" & StepGenTag & StepGenDirPin,     -- I/O 39    GPIO_1 04   04      Dir_5
+        IOPortTag & x"04" & StepGenTag & StepGenStepPin,    -- I/O 40    GPIO_1 05   05      Step_4
+        IOPortTag & x"04" & StepGenTag & StepGenDirPin,     -- I/O 41    GPIO_1 06   06      Dir_4
+        IOPortTag & x"03" & StepGenTag & StepGenStepPin,    -- I/O 42    GPIO_1 07   07      Step_3
+        IOPortTag & x"03" & StepGenTag & StepGenDirPin,     -- I/O 43    GPIO_1 08   08      Dir_3
+        IOPortTag & x"02" & StepGenTag & StepGenStepPin,    -- I/O 44    GPIO_1 09   09      Step_2
+        IOPortTag & x"02" & StepGenTag & StepGenDirPin,     -- I/O 45    GPIO_1 10   10      Dir_2
+        IOPortTag & x"01" & StepGenTag & StepGenStepPin,    -- I/O 46    GPIO_1 11   13      Step_1
+        IOPortTag & x"01" & StepGenTag & StepGenDirPin,     -- I/O 47    GPIO_1 12   14      Dir_1
+        IOPortTag & x"00" & StepGenTag & StepGenStepPin,    -- I/O 48    GPIO_1 13   15      Step_0
+        IOPortTag & x"00" & StepGenTag & StepGenDirPin,     -- I/O 49    GPIO_1 14   16      Dir_0
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 50    GPIO_1 15   17      Step4_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 51    GPIO_1 16   18      Step5_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 52    GPIO_1 17   19      Step2_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 53    GPIO_1 18   20      Step3_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 54    GPIO_1 19   21      Step0_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 55    GPIO_1 20   22      Step1_Enable
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 56    GPIO_1 21   23      GP_Output_00
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 57    GPIO_1 22   24      GP_Output_08
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 58    GPIO_1 23   25      GP_Output_01
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 59    GPIO_1 24   26      GP_Output_09
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 60    GPIO_1 25   27      GP_Output_02
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 61    GPIO_1 26   28      GP_Output_10
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 62    GPIO_1 27   31      GP_Output_03
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 63    GPIO_1 28   32      GP_Output_11
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 64    GPIO_1 29   33      GP_Output_04
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 65    GPIO_1 30   34      GP_Output_12
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 66    GPIO_1 31   35      GP_Output_05
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 67    GPIO_1 32   36      GP_Output_13
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 68    GPIO_1 33   37      GP_Output_06
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 69    GPIO_1 34   38      GP_Output_14
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 70    GPIO_1 35   39      GP_Output_07
+        IOPortTag & x"00" & NullTag & NullPin,              -- I/O 71    GPIO_1 36   40      GP_Output_15
+      
+          -- Remainder of 144 pin descriptors are unused
+        emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+        emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+        emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+        emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+        emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+        emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+    	emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,
+		emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin,emptypin);
+
+end package Pintypes; --PIN_Cramps_3x24_dpll_irq

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24.sv
@@ -32,5 +32,7 @@ parameter BoardAdaptor          = 0;
     parameter ADC               = "DE0-Nano-SoC";
     parameter Mux_En            = 1;
     parameter Capsense          = 0;
-    parameter NumSense          = 0;
+    parameter NumSense          = 4;
+                              // Capsense Pins: '{.. etc , Sensor1, Sensor0, charge out}   // GPIO 0-71
+    parameter int Capsense_Pins[NumSense:0]   = '{ 40, 39,      38,      37, 36        };
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24.sv
@@ -30,6 +30,7 @@ parameter BoardAdaptor          = 0;
     parameter MuxGPIOIOWidth    = IOWidth/NumGPIO;
     parameter MuxLedWidth       = LEDCount/NumGPIO;
     parameter ADC               = "DE0-Nano-SoC";
+    parameter Mux_En            = 1;
     parameter Capsense          = 0;
     parameter NumSense          = 0;
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap.sv
@@ -30,6 +30,7 @@ parameter BoardAdaptor          = 0;
     parameter MuxGPIOIOWidth    = IOWidth/NumGPIO;
     parameter MuxLedWidth       = LEDCount/NumGPIO;
     parameter ADC               = "DE0-Nano-SoC";
+    parameter Mux_En            = 1;
     parameter Capsense          = 1;
     parameter NumSense          = 4;
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap.sv
@@ -33,4 +33,6 @@ parameter BoardAdaptor          = 0;
     parameter Mux_En            = 1;
     parameter Capsense          = 1;
     parameter NumSense          = 4;
+                              // Capsense Pins: '{.. etc , Sensor1, Sensor0, charge out}   // GPIO 0-71
+    parameter int Capsense_Pins[NumSense:0]   = '{ 40, 39,      38,      37, 36        };
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc.sv
@@ -30,6 +30,7 @@ parameter BoardAdaptor          = 0;
     parameter MuxGPIOIOWidth    = IOWidth/NumGPIO;
     parameter MuxLedWidth       = LEDCount/NumGPIO;
     parameter ADC               = "DE0-Nano-SoC";
+    parameter Mux_En            = 1;
     parameter Capsense          = 1;
     parameter NumSense          = 4;
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc.sv
@@ -33,4 +33,6 @@ parameter BoardAdaptor          = 0;
     parameter Mux_En            = 1;
     parameter Capsense          = 1;
     parameter NumSense          = 4;
+                              // Capsense Pins: '{.. etc , Sensor1, Sensor0, charge out}   // GPIO 0-71
+    parameter int Capsense_Pins[NumSense:0]   = '{ 40, 39,      38,      37, 36        };
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc_bspi.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc_bspi.sv
@@ -30,6 +30,7 @@ parameter BoardAdaptor          = 0;
     parameter MuxGPIOIOWidth    = IOWidth/NumGPIO;
     parameter MuxLedWidth       = LEDCount/NumGPIO;
     parameter ADC               = "DE0-Nano-SoC";
+    parameter Mux_En            = 1;
     parameter Capsense          = 1;
     parameter NumSense          = 4;
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc_bspi.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc_bspi.sv
@@ -33,4 +33,6 @@ parameter BoardAdaptor          = 0;
     parameter Mux_En            = 1;
     parameter Capsense          = 1;
     parameter NumSense          = 4;
+                              // Capsense Pins: '{.. etc , Sensor1, Sensor0, charge out}   // GPIO 0-71
+    parameter int Capsense_Pins[NumSense:0]   = '{ 40, 39,      38,      37, 36        };
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc_dbspi.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc_dbspi.sv
@@ -30,6 +30,7 @@ parameter BoardAdaptor          = 0;
     parameter MuxGPIOIOWidth    = IOWidth/NumGPIO;
     parameter MuxLedWidth       = LEDCount/NumGPIO;
     parameter ADC               = "DE0-Nano-SoC";
+    parameter Mux_En            = 1;
     parameter Capsense          = 1;
     parameter NumSense          = 4;
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc_dbspi.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_3x24_cap_enc_dbspi.sv
@@ -33,4 +33,6 @@ parameter BoardAdaptor          = 0;
     parameter Mux_En            = 1;
     parameter Capsense          = 1;
     parameter NumSense          = 4;
+                              // Capsense Pins: '{.. etc , Sensor1, Sensor0, charge out}   // GPIO 0-71
+    parameter int Capsense_Pins[NumSense:0]   = '{ 40, 39,      38,      37, 36        };
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_st_fpga_soc_dc1f_ss.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_st_fpga_soc_dc1f_ss.sv
@@ -1,0 +1,35 @@
+package boardtype;
+// DE0-Nano Dev kit and I/O adaptors specific info
+//   {STRAIGHT=0,DB25=1} BoardAdaptor;
+
+parameter BoardAdaptor          = 0;
+    parameter ClockHigh         = 200000000;    // 200 MHz
+    parameter ClockMed          = 100000000;    // 100 MHz
+    parameter ClockLow          =  50000000;    //  50 MHz
+//    parameter BoardNameLow      = 32'h41524554;        // "TERA"
+//    parameter BoardNameHigh     = 32'h4E304544;        // "DE0N"
+    parameter BoardNameLow      = 32'h4153454D;        // "MESA"
+    parameter BoardNameHigh     = 32'h35324935;        // "5I25"
+    parameter FPGASize          = 9;            // Reported as 32-bit value in IDROM.vhd (9 matches Mesanet value for 5i25)
+                                                    //   FIXME: Figure out Mesanet encoding and put something sensible here
+    parameter FPGAPins          = 144;    // Total Number of available I/O pins for Hostmot2 use Reported as 32-bit value in IDROM.vhd
+                                                    // Proposal: On DE0 NANO board Limit to total count of gpios + arduinoconnectors + ltc + adc I/Os
+                                            //   Maximum of 144 pindesc entries currently hard-coded in IDROM.vhd
+    parameter IOPorts           = 3;            // Number of external ports (DE0-Nano_DB25 can have 2 on each 40-pin expansion header)
+    parameter IOWidth           = 72;            // Number of total I/O pins = IOPorts * PortWidth
+    parameter PortWidth         = 24;            // Number of I/O pins per port: 17 per DB25
+    parameter LIOWidth          = 0;            // Number of local I/Os (used for on-board serial-port on Mesanet cards)
+    parameter LEDCount          = 0;            // Number of LEDs
+    parameter SepClocks         = "true";            // Deprecated
+    parameter OneWS             = "true";            // Deprecated
+    parameter BusWidth          = 32;
+    parameter AddrWidth         = 16;
+
+    parameter GPIOWidth         = 36;
+    parameter NumGPIO           = 2;
+    parameter MuxGPIOIOWidth    = IOWidth/NumGPIO;
+    parameter MuxLedWidth       = LEDCount/NumGPIO;
+    parameter ADC               = "DE0-Nano-SoC";
+    parameter Capsense          = 0;
+    parameter NumSense          = 4;
+endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_st_fpga_soc_dc1f_ss.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_st_fpga_soc_dc1f_ss.sv
@@ -30,6 +30,7 @@ parameter BoardAdaptor          = 0;
     parameter MuxGPIOIOWidth    = IOWidth/NumGPIO;
     parameter MuxLedWidth       = LEDCount/NumGPIO;
     parameter ADC               = "DE0-Nano-SoC";
+    parameter Mux_En            = 0;
     parameter Capsense          = 0;
     parameter NumSense          = 4;
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_st_fpga_soc_dc1f_ss.sv
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/atlas_st_fpga_soc_dc1f_ss.sv
@@ -33,4 +33,6 @@ parameter BoardAdaptor          = 0;
     parameter Mux_En            = 0;
     parameter Capsense          = 0;
     parameter NumSense          = 4;
+                              // Capsense Pins: '{.. etc , Sensor1, Sensor0, charge out}   // GPIO 0-71
+    parameter int Capsense_Pins[NumSense:0]   = '{ 40, 39,      38,      37, 36        };
 endpackage //_HeaderIncluded

--- a/HW/hm2/config/DExx_Nano_xxx_Cramps/readme.md
+++ b/HW/hm2/config/DExx_Nano_xxx_Cramps/readme.md
@@ -1,0 +1,10 @@
+Shared configs for the DE0_Nano_SoC_Cramps and DE10_Nano_FB_Cramps projects
+The DExx ..._Cramps projects are minimalistic as only the hm2 cores in current configs are included.
+
+A new config is added by creating and then editing a new copy of these 2 files.
+
+    PIN_(your-custom-name).vhd
+    atlas_(your-custom-name).sv
+
+If you wish to create a new config including a not yet (in current configs) included core,
+post a DExx_.._Cramps new core feature request. (in the GGroup).

--- a/HW/hm2/hm3_socfpga.qip
+++ b/HW/hm2/hm3_socfpga.qip
@@ -32,6 +32,8 @@ set_global_assignment -name VHDL_FILE ../../hm2/wrappers/MakeTPPWMGens.vhd
 set_global_assignment -name VHDL_FILE ../../hm2/wrappers/MakeSPIs.vhd
 set_global_assignment -name VHDL_FILE ../../hm2/wrappers/MakeBSPIs.vhd
 set_global_assignment -name VHDL_FILE ../../hm2/wrappers/MakeDBSPIs.vhd
+#set_global_assignment -name VHDL_FILE ../../hm2/wrappers/MakeSSIs.vhd
+set_global_assignment -name VHDL_FILE ../../hm2/wrappers/MakeSSerials.vhd
 
 # HM2 cores:
 set_global_assignment -name VHDL_FILE ../../hm2/kubstepgenzi.vhd
@@ -70,11 +72,11 @@ set_global_assignment -name VHDL_FILE ../../hm2/idrom.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/wavegen.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/dpram.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/twidrom.vhd
-#set_global_assignment -name VHDL_FILE ../../hm2/sslbprom.vhd
-#set_global_assignment -name VHDL_FILE ../../hm2/sslbpram.vhd
-#set_global_assignment -name VHDL_FILE ../../hm2/adpram.vhd
-#set_global_assignment -name VHDL_FILE ../../hm2/uartx8.vhd
-#set_global_assignment -name VHDL_FILE ../../hm2/uartr8.vhd
+set_global_assignment -name VHDL_FILE ../../hm2/sslbprom.vhd
+set_global_assignment -name VHDL_FILE ../../hm2/sslbpram.vhd
+set_global_assignment -name VHDL_FILE ../../hm2/adpram.vhd
+set_global_assignment -name VHDL_FILE ../../hm2/uartx8.vhd
+set_global_assignment -name VHDL_FILE ../../hm2/uartr8.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/waveram.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/fanucabs.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/binosc.vhd
@@ -84,8 +86,8 @@ set_global_assignment -name VHDL_FILE ../../hm2/idrom.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/sine16.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/resrom.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/syncwavegen.vhd
-#set_global_assignment -name VHDL_FILE ../../hm2/sserialwa.vhd
+set_global_assignment -name VHDL_FILE ../../hm2/sserialwa.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/d8o8sqw.vhd
-#set_global_assignment -name VHDL_FILE ../../hm2/d8o8sqws.vhd
+set_global_assignment -name VHDL_FILE ../../hm2/d8o8sqws.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/b32qcondmac2w.vhd
 #set_global_assignment -name VHDL_FILE ../../hm2/resroms.vhd

--- a/HW/hm2/hostmot3.vhd
+++ b/HW/hm2/hostmot3.vhd
@@ -170,14 +170,14 @@ constant DBSPIs: integer := NumberOfModules(TheModuleID,DBSPITag);
 --constant PktUARTs: integer := NumberOfModules(TheModuleID,PktUARTRTag); -- assumption
 --constant WaveGens: integer := NumberOfModules(TheModuleID,WaveGenTag);
 --constant ResolverMods: integer := NumberOfModules(TheModuleID,ResModTag);
---constant SSerials: integer := NumberOfModules(TheModuleID,SSerialTag);
---type  SSerialType is array(0 to 3) of integer;
---constant UARTSPerSSerial: SSerialType :=(
---(InputPinsPerModule(ThePinDesc,SSerialTag,0)),
---(InputPinsPerModule(ThePinDesc,SSerialTag,1)),
---(InputPinsPerModule(ThePinDesc,SSerialTag,2)),
---(InputPinsPerModule(ThePinDesc,SSerialTag,3)));
---constant MaxUARTSPerSSerial: integer := MaxInputPinsPerModule(ThePinDesc,SSerialTag);
+constant SSerials: integer := NumberOfModules(TheModuleID,SSerialTag);
+-- type  SSerialType is array(0 to 3) of integer;
+-- constant UARTSPerSSerial: SSerialType :=(
+-- (InputPinsPerModule(ThePinDesc,SSerialTag,0)),
+-- (InputPinsPerModule(ThePinDesc,SSerialTag,1)),
+-- (InputPinsPerModule(ThePinDesc,SSerialTag,2)),
+-- (InputPinsPerModule(ThePinDesc,SSerialTag,3)));
+constant MaxUARTSPerSSerial: integer := MaxInputPinsPerModule(ThePinDesc,SSerialTag);
 --constant	Twiddlers: integer := NumberOfModules(TheModuleID,TwiddlerTag);
 --constant InputsPerTwiddler: integer := MaxInputPinsPerModule(ThePinDesc,TwiddlerTag)+MaxIOPinsPerModule(ThePinDesc,TwiddlerTag);
 --constant OutputsPerTwiddler: integer := MaxOutputPinsPerModule(ThePinDesc,TwiddlerTag); -- MaxOutputsPer pin counts I/O pins also
@@ -725,105 +725,58 @@ GenMakeDBSPIs: if DBSPIs >0  generate
             rates			=>  rates
         );
 end generate;
-
 --
--- 	makesssimod:  if SSSIs >0  generate
--- 	signal LoadSSSIData0: std_logic_vector(SSSIs -1 downto 0);
--- 	signal ReadSSSIData0: std_logic_vector(SSSIs -1 downto 0);
--- 	signal ReadSSSIData1: std_logic_vector(SSSIs -1 downto 0);
--- 	signal LoadSSSIControl: std_logic_vector(SSSIs -1 downto 0);
--- 	signal ReadSSSIControl: std_logic_vector(SSSIs -1 downto 0);
--- 	signal SSSIClk: std_logic_vector(SSSIs -1 downto 0);
--- 	signal SSSIData: std_logic_vector(SSSIs -1 downto 0);
--- 	signal SSSIBusyBits: std_logic_vector(SSSIs -1 downto 0);
--- 	signal SSSIDAVBits: std_logic_vector(SSSIs -1 downto 0);
--- 	signal SSSIDataSel0 : std_logic;
--- 	signal SSSIDataSel1 : std_logic;
--- 	signal SSSIControlSel : std_logic;
--- 	signal GlobalPStartSSSI : std_logic;
--- 	signal GlobalSSSIBusySel : std_logic;
--- 	signal GlobalTStartSSSI : std_logic;
--- 		begin
--- 		makesssis: for i in 0 to SSSIs -1 generate
--- 			sssi: entity work.SimpleSSI
--- 			port  map (
--- 				clk => clklow,
--- 				ibus => ibusint,
--- 				obus => obusint,
--- 				loadcontrol => LoadSSSIControl(i),
--- 				lstart => LoadSSSIData0(i),
--- 				pstart => GlobalPstartSSSI,
--- 				timers => RateSources,
--- 				readdata0 => ReadSSSIData0(i),
--- 				readdata1 => ReadSSSIData1(i),
--- 				readcontrol => ReadSSSIControl(i),
--- 				busyout => SSSIBusyBits(i),
--- 				davout => SSSIDAVBits(i),
--- 				ssiclk => SSSIClk(i),
--- 				ssidata => SSSIData(i)
--- 				);
--- 		end generate;
---
--- 		SSSIDecodeProcess : process (Aint,Readstb,writestb,SSSIDataSel0,GlobalSSSIBusySel,
--- 		                             SSSIBusyBits,SSSIDAvBits,SSSIDataSel1,SSSIControlSel)
--- 		begin
--- 			if Aint(AddrWidth-1 downto 8) = SSSIDataAddr0 then	 --  SSSI data register select 0
--- 				SSSIDataSel0 <= '1';
--- 			else
--- 				SSSIDataSel0 <= '0';
--- 			end if;
--- 			if Aint(AddrWidth-1 downto 8) = SSSIDataAddr1 then	 --  SSSI data register select 1
--- 				SSSIDataSel1 <= '1';
--- 			else
--- 				SSSIDataSel1 <= '0';
--- 			end if;
---
--- 			if Aint(AddrWidth-1 downto 8) = SSSIControlAddr then	 --  SSSI control register select
--- 				SSSIControlSel <= '1';
--- 			else
--- 				SSSIControlSel <= '0';
--- 			end if;
--- 			if Aint(AddrWidth-1 downto 8) = SSSIGlobalPStartAddr and writestb = '1' then	 --
--- 				GlobalPStartSSSI <= '1';
--- 			else
--- 				GlobalPStartSSSI <= '0';
--- 			end if;
--- 			if Aint(AddrWidth-1 downto 8) = SSSIGlobalPStartAddr and readstb = '1' then	 --
--- 				GlobalSSSIBusySel <= '1';
--- 			else
--- 				GlobalSSSIBusySel <= '0';
--- 			end if;
--- 			LoadSSSIData0 <= OneOfNDecode(SSSIs,SSSIDataSel0,writestb,Aint(7 downto 2)); -- 64 max
--- 			ReadSSSIData0 <= OneOfNDecode(SSSIs,SSSIDataSel0,Readstb,Aint(7 downto 2));
--- 			ReadSSSIData1 <= OneOfNDecode(SSSIs,SSSIDataSel1,Readstb,Aint(7 downto 2));
--- 			LoadSSSIControl <= OneOfNDecode(SSSIs,SSSIControlSel,writestb,Aint(7 downto 2));
--- 			ReadSSSIControl <= OneOfNDecode(SSSIs,SSSIControlSel,Readstb,Aint(7 downto 2));
--- 			obusint <= (others => 'Z');
--- 			if GlobalSSSIBusySel = '1' then
--- 				obusint(SSSIs -1 downto 0) <= SSSIBusyBits;
--- 				obusint(31 downto SSSIs) <= (others => '0');
--- 			end if;
--- 		end process SSSIDecodeProcess;
---
--- 		DoSSIPins: process(SSSIClk, IOBitsCorein,SSSIDavBits)
--- 		begin
--- 			for i in 0 to IOWidth -1 loop				-- loop through all the external I/O pins
--- 				if ThePinDesc(i)(15 downto 8) = SSSITag then 	-- this hideous masking of pinnumbers/vs pintype is why they should be separate bytes, maybe IDROM type 4...
--- 					case (ThePinDesc(i)(7 downto 0)) is	--secondary pin function, drop MSB
--- 						when SSSIClkPin =>
--- 							IOBitsCorein(i) <= SSSIClk(conv_integer(ThePinDesc(i)(23 downto 16)));
--- 						when SSSIClkEnPin =>
--- 							IOBitsCorein(i) <= '0';		-- for RS-422 daughtercards that have drive enables
--- 						when SSSIDAVPin =>
--- 							IOBitsCorein(i) <= SSSIDAVBits(conv_integer(ThePinDesc(i)(23 downto 16)));
--- 						when SSSIDataPin =>
--- 							SSSIData(conv_integer(ThePinDesc(i)(23 downto 16))) <= IOBitsCorein(i);
--- 						when others => null;
--- 					end case;
--- 				end if;
--- 			end loop;
--- 		end process;
--- 	end generate;
+-- GenMakeSSSIs: if SSSIs >0  generate
+--     MakeSSSIs : entity work.MakeSSSIs
+--     generic map (
+--         ThePinDesc => ThePinDesc,
+--         ClockHigh => ClockHigh,
+--         ClockMed => ClockMed,
+--         ClockLow  => ClockLow,
+--         BusWidth  => BusWidth,
+--         AddrWidth  => AddrWidth,
+--         IOWidth  => IOWidth,
+--         STEPGENs  => STEPGENs,
+--         StepGenTableWidth => StepGenTableWidth,
+--         UseStepGenPreScaler => UseStepGenPreScaler,
+--         UseStepgenIndex => UseStepgenIndex,
+--         UseStepgenProbe => UseStepgenProbe,
+--         timersize  => 14,
+--         asize  => 48,
+--         rsize  => 32,
+--         HM2DPLLs => HM2DPLLs,
+--         MuxedQCounters  => MuxedQCounters,
+--         MuxedQCountersMIM  => MuxedQCountersMIM,
+--         PWMGens  => PWMGens,
+--         PWMRefWidth  => PWMRefWidth,
+--         UsePWMEnas  => UsePWMEnas,
+--         TPPWMGens  => TPPWMGens,
+--         QCounters  => QCounters,
+--         UseMuxedProbe  => UseMuxedProbe,
+--         UseProbe  => UseProbe,
+--         SPIs  => SPIs,
+--         BSPIs  => BSPIs,
+--         BSPICSWidth  => BSPICSWidth,
+--         DBSPIs  => DBSPIs,
+--         DBSPICSWidth  => DBSPICSWidth,
+--         SSSIs  => SSSIs
+--         )
+--         port map (
+--             ibus			=>	ibusint,
+--             obusint			=>	obusint,
+--             Aint			=>	Aint,
+--             readstb			=>	readstb,
+--             writestb		=>	writestb,
+--             CoreDataOut		=>	CoreDataOut,
+--             IOBitsCorein	=>	IOBitsCorein,
+--             clklow			=>	clklow,
+--             clkmed			=>	clkmed,
+--             clkhigh			=>	clkhigh,
+--             PRobe			=>  PRobe,
+--             RateSources		=>  RateSources,
+--             rates			=>  rates
+--         );
+-- end generate;
 --
 -- 	makeFAbsmod:  if FAbss >0  generate
 -- 	signal LoadFAbsData0: std_logic_vector(FAbss -1 downto 0);
@@ -1725,141 +1678,59 @@ end generate;
 -- 			end loop;
 -- 		end process;
 -- 	end generate;
---
--- 	makesserialmod:  if SSerials >0  generate
--- 	signal LoadSSerialCommand: std_logic_vector(SSerials -1 downto 0);
--- 	signal ReadSSerialCommand: std_logic_vector(SSerials -1 downto 0);
--- 	signal LoadSSerialData: std_logic_vector(SSerials -1 downto 0);
--- 	signal ReadSSerialData: std_logic_vector(SSerials -1 downto 0);
--- 	signal LoadSSerialRAM0: std_logic_vector(SSerials -1 downto 0);
--- 	signal ReadSSerialRAM0: std_logic_vector(SSerials -1 downto 0);
--- 	signal LoadSSerialRAM1: std_logic_vector(SSerials -1 downto 0);
--- 	signal ReadSSerialRAM1: std_logic_vector(SSerials -1 downto 0);
--- 	signal LoadSSerialRAM2: std_logic_vector(SSerials -1 downto 0);
--- 	signal ReadSSerialRAM2: std_logic_vector(SSerials -1 downto 0);
--- 	signal LoadSSerialRAM3: std_logic_vector(SSerials -1 downto 0);
--- 	signal ReadSSerialRAM3: std_logic_vector(SSerials -1 downto 0);
--- 	type  SSerialRXType is array(SSerials-1 downto 0) of std_logic_vector(MaxUARTsPerSSerial-1 downto 0);
--- 	signal SSerialRX: SSerialRXType;
--- 	type  SSerialTXType is array(SSerials-1 downto 0) of std_logic_vector(MaxUARTsPerSSerial-1 downto 0);
--- 	signal SSerialTX: SSerialTXType;
--- 	type  SSerialTXEnType is array(SSerials-1 downto 0) of std_logic_vector(MaxUARTsPerSSerial-1 downto 0);
--- 	signal SSerialTXEn: SSerialTXEnType;
--- 	signal SSerialTestBits: std_logic_vector(SSerials -1 downto 0);
--- 	signal SSerialCommandSel: std_logic;
--- 	signal SSerialDataSel: std_logic;
--- 	signal SSerialRAMSel0: std_logic;
--- 	signal SSerialRAMSel1: std_logic;
--- 	signal SSerialRAMSel2: std_logic;
--- 	signal SSerialRAMSel3: std_logic;
--- 	begin
--- 		makesserials: for i in 0 to SSerials -1 generate
--- 			asserial: entity work.sserialwa
--- 			generic map (
--- 				Ports => UARTSPerSSerial(i),
--- 				InterfaceRegs => UARTSPerSSerial(i),	-- must be power of 2
--- 				BaseClock => ClockMed,
--- 				NeedCRC8 => true
--- 			)
--- 			port map(
--- 				clk  => clklow,
--- 				clkmed => clkmed,
--- 				ibus  => ibusint,
--- 				obus  => obusint,
--- 				hloadcommand  => LoadSSerialCommand(i),
--- 				hreadcommand  => ReadSSerialCommand(i),
--- 				hloaddata  => LoadSSerialData(i),
--- 				hreaddata  => ReadSSerialData(i),
--- 				regaddr  =>  Aint(log2(UARTSPerSSerial(i))+1 downto 2),
--- 				hloadregs0  => LoadSSerialRAM0(i),
--- 				hreadregs0  => ReadSSerialRAM0(i),
--- 				hloadregs1  => LoadSSerialRAM1(i),
--- 				hreadregs1  => ReadSSerialRAM1(i),
--- 				hloadregs2  => LoadSSerialRAM2(i),
--- 				hreadregs2  => ReadSSerialRAM2(i),
--- 				hloadregs3  => LoadSSerialRAM3(i),
--- 				hreadregs3  => ReadSSerialRAM3(i),
--- 				rxserial  =>  SSerialRX(i)(UARTSPerSSerial(i) -1 downto 0),
--- 				txserial  =>  SSerialTX(i)(UARTSPerSSerial(i) -1 downto 0),
--- 				txenable  =>  SSerialTXEn(i)(UARTSPerSSerial(i) -1 downto 0),
--- 				testbit  =>   SSerialTestBits(i)
--- 				);
--- 		end generate;
---
--- 		SSerialDecodeProcess : process (Aint,Readstb,writestb,SSerialCommandSel,SSerialDataSel,
--- 		                                SSerialRAMSel0,SSerialRAMSel1,SSerialRAMSel2,SSerialRAMSel3)
--- 		begin
--- 			if Aint(AddrWidth-1 downto 8) = SSerialCommandAddr then
--- 				SSerialCommandSel <= '1';
--- 			else
--- 				SSerialCommandSel <= '0';
--- 			end if;
--- 			if Aint(AddrWidth-1 downto 8) = SSerialDataAddr then
--- 				SSerialDataSel <= '1';
--- 			else
--- 				SSerialDataSel <= '0';
--- 			end if;
--- 			if Aint(AddrWidth-1 downto 8) = SSerialRAMAddr0 then
--- 				SSerialRAMSel0 <= '1';
--- 			else
--- 				SSerialRAMSel0 <= '0';
--- 			end if;
--- 			if Aint(AddrWidth-1 downto 8) = SSerialRAMAddr1 then
--- 				SSerialRAMSel1 <= '1';
--- 			else
--- 				SSerialRAMSel1 <= '0';
--- 			end if;
--- 			if Aint(AddrWidth-1 downto 8) = SSerialRAMAddr2 then
--- 				SSerialRAMSel2 <= '1';
--- 			else
--- 				SSerialRAMSel2 <= '0';
--- 			end if;
--- 			if Aint(AddrWidth-1 downto 8) = SSerialRAMAddr3 then
--- 				SSerialRAMSel3 <= '1';
--- 			else
--- 				SSerialRAMSel3 <= '0';
--- 			end if;
--- 			LoadSSerialCommand <= OneOfNDecode(SSerials,SSerialCommandSel,writestb,Aint(7 downto 6));
--- 			ReadSSerialCommand <= OneOfNDecode(SSerials,SSerialCommandSel,Readstb,Aint(7 downto 6));
--- 			LoadSSerialData <= OneOfNDecode(SSerials,SSerialDataSel,writestb,Aint(7 downto 6));
--- 			ReadSSerialData <= OneOfNDecode(SSerials,SSerialDataSel,Readstb,Aint(7 downto 6));
--- 			LoadSSerialRam0 <= OneOfNDecode(SSerials,SSerialRAMSel0,writestb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max, this implies 4 max sserials
--- 			ReadSSerialRam0 <= OneOfNDecode(SSerials,SSerialRAMSel0,Readstb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max, this implies 4 max sserials
--- 			LoadSSerialRam1 <= OneOfNDecode(SSerials,SSerialRAMSel1,writestb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max, this implies 4 max sserials
--- 			ReadSSerialRam1 <= OneOfNDecode(SSerials,SSerialRAMSel1,Readstb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max
--- 			LoadSSerialRam2 <= OneOfNDecode(SSerials,SSerialRAMSel2,writestb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max
--- 			ReadSSerialRam2 <= OneOfNDecode(SSerials,SSerialRAMSel2,Readstb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max
--- 			LoadSSerialRam3 <= OneOfNDecode(SSerials,SSerialRAMSel3,writestb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max
--- 			ReadSSerialRam3 <= OneOfNDecode(SSerials,SSerialRAMSel3,Readstb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max
---         report "Max UARTS per sserial " & integer'image(MaxUARTSPerSSerial);
---         report "UARTS per sserial 0 " &  integer 'image(UARTSPerSSerial(0));
---         report "UARTS per sserial 1 " &  integer 'image(UARTSPerSSerial(1));
---         report "UARTS per sserial 2 " &  integer 'image(UARTSPerSSerial(2));
---         report "UARTS per sserial 3 " &  integer 'image(UARTSPerSSerial(3));
---
---
--- 		end process SSerialDecodeProcess;
---
--- 		DoSSerialPins: process(SSerialTX, SSerialTXEn, SSerialTestBits, IOBitsCorein)
--- 		begin
--- 			for i in 0 to IOWidth -1 loop				-- loop through all the external I/O pins
--- 				if ThePinDesc(i)(15 downto 8) = SSerialTag then 	-- this hideous masking of pinnumbers/vs pintype is why they should be separate bytes, maybe IDROM type 4...
--- 					if (ThePinDesc(i)(7 downto 0) and x"F0") = x"80" then 	-- txouts match 8X
--- 						IOBitsCorein(i) <=   SSerialTX(conv_integer(ThePinDesc(i)(23 downto 16)))(conv_integer(ThePinDesc(i)(3 downto 0))-1);	-- 16 max ports
--- 					end if;
--- 					if (ThePinDesc(i)(7 downto 0) and x"F0") = x"90" then 	-- txens match 9X
--- 						IOBitsCorein(i) <= not SSerialTXEn(conv_integer(ThePinDesc(i)(23 downto 16)))(conv_integer(ThePinDesc(i)(3 downto 0))-1); 	-- 16 max ports
--- 					end if;
--- 					if (ThePinDesc(i)(7 downto 0) and x"F0") = x"00" then 	-- rxins match 0X
--- 						SSerialRX(conv_integer(ThePinDesc(i)(23 downto 16)))(conv_integer(ThePinDesc(i)(3 downto 0))-1) <= IOBitsCorein(i);		-- 16 max ports
--- 					end if;
--- 					if ThePinDesc(i)(7 downto 0) = SSerialTestPin then
--- 						IOBitsCorein(i) <= SSerialTestBits(i);
--- 					end if;
--- 				end if;
--- 			end loop;
--- 		end process;
--- 	end generate;
+
+GenMakeSSerials: if SSerials >0  generate
+    MakeSSerials : entity work.MakeSSerials
+    generic map (
+        ThePinDesc => ThePinDesc,
+        ClockHigh => ClockHigh,
+        ClockMed => ClockMed,
+        ClockLow  => ClockLow,
+        BusWidth  => BusWidth,
+        AddrWidth  => AddrWidth,
+        IOWidth  => IOWidth,
+        STEPGENs  => STEPGENs,
+        StepGenTableWidth => StepGenTableWidth,
+        UseStepGenPreScaler => UseStepGenPreScaler,
+        UseStepgenIndex => UseStepgenIndex,
+        UseStepgenProbe => UseStepgenProbe,
+        timersize  => 14,
+        asize  => 48,
+        rsize  => 32,
+        HM2DPLLs => HM2DPLLs,
+        MuxedQCounters  => MuxedQCounters,
+        MuxedQCountersMIM  => MuxedQCountersMIM,
+        PWMGens  => PWMGens,
+        PWMRefWidth  => PWMRefWidth,
+        UsePWMEnas  => UsePWMEnas,
+        TPPWMGens  => TPPWMGens,
+        QCounters  => QCounters,
+        UseMuxedProbe  => UseMuxedProbe,
+        UseProbe  => UseProbe,
+        SPIs  => SPIs,
+        BSPIs  => BSPIs,
+        BSPICSWidth  => BSPICSWidth,
+        DBSPIs  => DBSPIs,
+        DBSPICSWidth  => DBSPICSWidth,
+        SSerials  => SSerials,
+        MaxUARTSPerSSerial  => MaxUARTSPerSSerial
+        )
+        port map (
+            ibus			=>	ibusint,
+            obusint			=>	obusint,
+            Aint			=>	Aint,
+            readstb			=>	readstb,
+            writestb		=>	writestb,
+            CoreDataOut		=>	CoreDataOut,
+            IOBitsCorein	=>	IOBitsCorein,
+            clklow			=>	clklow,
+            clkmed			=>	clkmed,
+            clkhigh			=>	clkhigh,
+            PRobe			=>  PRobe,
+            RateSources		=>  RateSources,
+            rates			=>  rates
+        );
+end generate;
 --
 -- 	maketwiddlermod:  if Twiddlers >0  generate
 -- 	signal LoadTwiddlerCommand: std_logic_vector(Twiddlers -1 downto 0);

--- a/HW/hm2/wrappers/MakeSSIs.vhd
+++ b/HW/hm2/wrappers/MakeSSIs.vhd
@@ -1,0 +1,174 @@
+library IEEE;
+use IEEE.std_logic_1164.all;  -- defines std_logic types
+use IEEE.std_logic_ARITH.ALL;
+use IEEE.std_logic_UNSIGNED.ALL;
+
+-- Copyright 2016 - 2017 (C)  Michael Brown Holotronic
+-- holotronic.dk
+
+-- This file is created for Machinekit intended use
+library pin;
+use pin.Pintypes.all;
+use work.IDROMConst.all;
+
+use work.oneofndecode.all;
+
+entity MakeSSSIs is
+    generic (
+        ThePinDesc: PinDescType := PinDesc;
+        ClockHigh: integer;
+        ClockMed: integer;
+        ClockLow: integer;
+        BusWidth: integer;
+        AddrWidth: integer;
+        IOWidth: integer;
+        STEPGENs: integer;
+        StepGenTableWidth: integer;
+        UseStepGenPreScaler: boolean;
+        UseStepgenIndex: boolean;
+        UseStepgenProbe: boolean;
+        timersize: integer;			-- = ~480 usec at 33 MHz, ~320 at 50 Mhz
+        asize: integer;
+        rsize: integer;
+        HM2DPLLs: integer;
+        MuxedQCounters: integer;
+        MuxedQCountersMIM: integer;
+        PWMGens: integer;
+        PWMRefWidth  : integer;
+        UsePWMEnas : boolean;
+        TPPWMGens : integer;
+        QCounters: integer;
+        UseMuxedProbe: boolean;
+        UseProbe: boolean;
+        SPIs: integer;
+        BSPIs: integer;
+        BSPICSWidth: integer;
+        DBSPIs: integer;
+        DBSPICSWidth: integer;
+        SSSIs: integer);
+    Port (
+        ibus : in std_logic_vector(BusWidth -1 downto 0) := (others => 'Z');
+        obusint : out std_logic_vector(BusWidth -1 downto 0) := (others => 'Z');
+        Aint: in std_logic_vector(AddrWidth -1 downto 2);
+        readstb : in std_logic;
+        writestb : in std_logic;
+        CoreDataOut :  inout std_logic_vector(IOWidth-1 downto 0) := (others => 'Z');
+        IOBitsCorein :  inout std_logic_vector(IOWidth-1 downto 0) := (others => '0');
+        clklow : in std_logic;
+        clkmed : in std_logic;
+        clkhigh : in std_logic;
+        Probe : inout std_logic;
+        RateSources: out std_logic_vector(4 downto 0) := (others => 'Z');
+        rates: out std_logic_vector (4 downto 0)
+    );
+
+end MakeSSSIs;
+
+
+architecture dataflow of MakeSSSIs is
+
+-- Signals
+
+-- I/O port related signals
+
+    begin
+
+	makesssimod:  if SSSIs >0  generate
+	signal LoadSSSIData0: std_logic_vector(SSSIs -1 downto 0);
+	signal ReadSSSIData0: std_logic_vector(SSSIs -1 downto 0);
+	signal ReadSSSIData1: std_logic_vector(SSSIs -1 downto 0);
+	signal LoadSSSIControl: std_logic_vector(SSSIs -1 downto 0);
+	signal ReadSSSIControl: std_logic_vector(SSSIs -1 downto 0);
+	signal SSSIClk: std_logic_vector(SSSIs -1 downto 0);
+	signal SSSIData: std_logic_vector(SSSIs -1 downto 0);
+	signal SSSIBusyBits: std_logic_vector(SSSIs -1 downto 0);
+	signal SSSIDAVBits: std_logic_vector(SSSIs -1 downto 0);
+	signal SSSIDataSel0 : std_logic;
+	signal SSSIDataSel1 : std_logic;
+	signal SSSIControlSel : std_logic;
+	signal GlobalPStartSSSI : std_logic;
+	signal GlobalSSSIBusySel : std_logic;
+	signal GlobalTStartSSSI : std_logic;
+		begin
+		makesssis: for i in 0 to SSSIs -1 generate
+			sssi: entity work.SimpleSSI
+			port  map (
+				clk => clklow,
+--				ibus => ibusint,
+				obus => obusint,
+				loadcontrol => LoadSSSIControl(i),
+				lstart => LoadSSSIData0(i),
+				pstart => GlobalPstartSSSI,
+				timers => RateSources,
+				readdata0 => ReadSSSIData0(i),
+				readdata1 => ReadSSSIData1(i),
+				readcontrol => ReadSSSIControl(i),
+				busyout => SSSIBusyBits(i),
+				davout => SSSIDAVBits(i),
+				ssiclk => SSSIClk(i),
+				ssidata => SSSIData(i)
+				);
+		end generate;
+
+		SSSIDecodeProcess : process (Aint,Readstb,writestb,SSSIDataSel0,GlobalSSSIBusySel,
+		                             SSSIBusyBits,SSSIDAvBits,SSSIDataSel1,SSSIControlSel)
+		begin
+			if Aint(AddrWidth-1 downto 8) = SSSIDataAddr0 then	 --  SSSI data register select 0
+				SSSIDataSel0 <= '1';
+			else
+				SSSIDataSel0 <= '0';
+			end if;
+			if Aint(AddrWidth-1 downto 8) = SSSIDataAddr1 then	 --  SSSI data register select 1
+				SSSIDataSel1 <= '1';
+			else
+				SSSIDataSel1 <= '0';
+			end if;
+
+			if Aint(AddrWidth-1 downto 8) = SSSIControlAddr then	 --  SSSI control register select
+				SSSIControlSel <= '1';
+			else
+				SSSIControlSel <= '0';
+			end if;
+			if Aint(AddrWidth-1 downto 8) = SSSIGlobalPStartAddr and writestb = '1' then	 --
+				GlobalPStartSSSI <= '1';
+			else
+				GlobalPStartSSSI <= '0';
+			end if;
+			if Aint(AddrWidth-1 downto 8) = SSSIGlobalPStartAddr and readstb = '1' then	 --
+				GlobalSSSIBusySel <= '1';
+			else
+				GlobalSSSIBusySel <= '0';
+			end if;
+			LoadSSSIData0 <= OneOfNDecode(SSSIs,SSSIDataSel0,writestb,Aint(7 downto 2)); -- 64 max
+			ReadSSSIData0 <= OneOfNDecode(SSSIs,SSSIDataSel0,Readstb,Aint(7 downto 2));
+			ReadSSSIData1 <= OneOfNDecode(SSSIs,SSSIDataSel1,Readstb,Aint(7 downto 2));
+			LoadSSSIControl <= OneOfNDecode(SSSIs,SSSIControlSel,writestb,Aint(7 downto 2));
+			ReadSSSIControl <= OneOfNDecode(SSSIs,SSSIControlSel,Readstb,Aint(7 downto 2));
+			obusint <= (others => 'Z');
+			if GlobalSSSIBusySel = '1' then
+				obusint(SSSIs -1 downto 0) <= SSSIBusyBits;
+				obusint(31 downto SSSIs) <= (others => '0');
+			end if;
+		end process SSSIDecodeProcess;
+
+		DoSSIPins: process(SSSIClk, IOBitsCorein,SSSIDavBits)
+		begin
+			for i in 0 to IOWidth -1 loop				-- loop through all the external I/O pins
+				if ThePinDesc(i)(15 downto 8) = SSSITag then 	-- this hideous masking of pinnumbers/vs pintype is why they should be separate bytes, maybe IDROM type 4...
+					case (ThePinDesc(i)(7 downto 0)) is	--secondary pin function, drop MSB
+						when SSSIClkPin =>
+							IOBitsCorein(i) <= SSSIClk(conv_integer(ThePinDesc(i)(23 downto 16)));
+						when SSSIClkEnPin =>
+							IOBitsCorein(i) <= '0';		-- for RS-422 daughtercards that have drive enables
+						when SSSIDAVPin =>
+							IOBitsCorein(i) <= SSSIDAVBits(conv_integer(ThePinDesc(i)(23 downto 16)));
+						when SSSIDataPin =>
+							SSSIData(conv_integer(ThePinDesc(i)(23 downto 16))) <= IOBitsCorein(i);
+						when others => null;
+					end case;
+				end if;
+			end loop;
+		end process;
+    end generate makesssimod;
+
+end dataflow;

--- a/HW/hm2/wrappers/MakeSSerials.vhd
+++ b/HW/hm2/wrappers/MakeSSerials.vhd
@@ -1,0 +1,220 @@
+library IEEE;
+use IEEE.std_logic_1164.all;  -- defines std_logic types
+use IEEE.std_logic_ARITH.ALL;
+use IEEE.std_logic_UNSIGNED.ALL;
+
+-- Copyright 2016 - 2017 (C)  Michael Brown Holotronic
+-- holotronic.dk
+
+-- This file is created for Machinekit intended use
+library pin;
+use pin.Pintypes.all;
+use work.IDROMConst.all;
+
+use work.oneofndecode.all;
+use work.InputPinsPerModule.all;
+use work.log2.all;
+
+entity MakeSSerials is
+    generic (
+        ThePinDesc: PinDescType := PinDesc;
+        ClockHigh: integer;
+        ClockMed: integer;
+        ClockLow: integer;
+        BusWidth: integer;
+        AddrWidth: integer;
+        IOWidth: integer;
+        STEPGENs: integer;
+        StepGenTableWidth: integer;
+        UseStepGenPreScaler: boolean;
+        UseStepgenIndex: boolean;
+        UseStepgenProbe: boolean;
+        timersize: integer;			-- = ~480 usec at 33 MHz, ~320 at 50 Mhz
+        asize: integer;
+        rsize: integer;
+        HM2DPLLs: integer;
+        MuxedQCounters: integer;
+        MuxedQCountersMIM: integer;
+        PWMGens: integer;
+        PWMRefWidth  : integer;
+        UsePWMEnas : boolean;
+        TPPWMGens : integer;
+        QCounters: integer;
+        UseMuxedProbe: boolean;
+        UseProbe: boolean;
+        SPIs: integer;
+        BSPIs: integer;
+        BSPICSWidth: integer;
+        DBSPIs: integer;
+        DBSPICSWidth: integer;
+        SSerials: integer;
+        MaxUARTSPerSSerial: integer);
+    Port (
+        ibus : in std_logic_vector(BusWidth -1 downto 0) := (others => 'Z');
+        obusint : out std_logic_vector(BusWidth -1 downto 0) := (others => 'Z');
+        Aint: in std_logic_vector(AddrWidth -1 downto 2);
+        readstb : in std_logic;
+        writestb : in std_logic;
+        CoreDataOut :  inout std_logic_vector(IOWidth-1 downto 0) := (others => 'Z');
+        IOBitsCorein :  inout std_logic_vector(IOWidth-1 downto 0) := (others => '0');
+        clklow : in std_logic;
+        clkmed : in std_logic;
+        clkhigh : in std_logic;
+        Probe : inout std_logic;
+        RateSources: out std_logic_vector(4 downto 0) := (others => 'Z');
+        rates: out std_logic_vector (4 downto 0)
+    );
+
+end MakeSSerials;
+
+
+architecture dataflow of MakeSSerials is
+
+-- Signals
+type  SSerialType is array(0 to 3) of integer;
+constant UARTSPerSSerial: SSerialType :=(
+(InputPinsPerModule(ThePinDesc,SSerialTag,0)),
+(InputPinsPerModule(ThePinDesc,SSerialTag,1)),
+(InputPinsPerModule(ThePinDesc,SSerialTag,2)),
+(InputPinsPerModule(ThePinDesc,SSerialTag,3)));
+
+-- I/O port related signals
+
+    begin
+
+	makesserialmod:  if SSerials >0  generate
+	signal LoadSSerialCommand: std_logic_vector(SSerials -1 downto 0);
+	signal ReadSSerialCommand: std_logic_vector(SSerials -1 downto 0);
+	signal LoadSSerialData: std_logic_vector(SSerials -1 downto 0);
+	signal ReadSSerialData: std_logic_vector(SSerials -1 downto 0);
+	signal LoadSSerialRAM0: std_logic_vector(SSerials -1 downto 0);
+	signal ReadSSerialRAM0: std_logic_vector(SSerials -1 downto 0);
+	signal LoadSSerialRAM1: std_logic_vector(SSerials -1 downto 0);
+	signal ReadSSerialRAM1: std_logic_vector(SSerials -1 downto 0);
+	signal LoadSSerialRAM2: std_logic_vector(SSerials -1 downto 0);
+	signal ReadSSerialRAM2: std_logic_vector(SSerials -1 downto 0);
+	signal LoadSSerialRAM3: std_logic_vector(SSerials -1 downto 0);
+	signal ReadSSerialRAM3: std_logic_vector(SSerials -1 downto 0);
+	type  SSerialRXType is array(SSerials-1 downto 0) of std_logic_vector(MaxUARTsPerSSerial-1 downto 0);
+	signal SSerialRX: SSerialRXType;
+	type  SSerialTXType is array(SSerials-1 downto 0) of std_logic_vector(MaxUARTsPerSSerial-1 downto 0);
+	signal SSerialTX: SSerialTXType;
+	type  SSerialTXEnType is array(SSerials-1 downto 0) of std_logic_vector(MaxUARTsPerSSerial-1 downto 0);
+	signal SSerialTXEn: SSerialTXEnType;
+	signal SSerialTestBits: std_logic_vector(SSerials -1 downto 0);
+	signal SSerialCommandSel: std_logic;
+	signal SSerialDataSel: std_logic;
+	signal SSerialRAMSel0: std_logic;
+	signal SSerialRAMSel1: std_logic;
+	signal SSerialRAMSel2: std_logic;
+	signal SSerialRAMSel3: std_logic;
+	begin
+		makesserials: for i in 0 to SSerials -1 generate
+			asserial: entity work.sserialwa
+			generic map (
+				Ports => UARTSPerSSerial(i),
+				InterfaceRegs => UARTSPerSSerial(i),	-- must be power of 2
+				BaseClock => ClockMed,
+				NeedCRC8 => true
+			)
+			port map(
+				clk  => clklow,
+				clkmed => clkmed,
+				ibus  => ibus,
+				obus  => obusint,
+				hloadcommand  => LoadSSerialCommand(i),
+				hreadcommand  => ReadSSerialCommand(i),
+				hloaddata  => LoadSSerialData(i),
+				hreaddata  => ReadSSerialData(i),
+				regaddr  =>  Aint(log2(UARTSPerSSerial(i))+1 downto 2),
+				hloadregs0  => LoadSSerialRAM0(i),
+				hreadregs0  => ReadSSerialRAM0(i),
+				hloadregs1  => LoadSSerialRAM1(i),
+				hreadregs1  => ReadSSerialRAM1(i),
+				hloadregs2  => LoadSSerialRAM2(i),
+				hreadregs2  => ReadSSerialRAM2(i),
+				hloadregs3  => LoadSSerialRAM3(i),
+				hreadregs3  => ReadSSerialRAM3(i),
+				rxserial  =>  SSerialRX(i)(UARTSPerSSerial(i) -1 downto 0),
+				txserial  =>  SSerialTX(i)(UARTSPerSSerial(i) -1 downto 0),
+				txenable  =>  SSerialTXEn(i)(UARTSPerSSerial(i) -1 downto 0),
+				testbit  =>   SSerialTestBits(i)
+				);
+		end generate;
+
+		SSerialDecodeProcess : process (Aint,Readstb,writestb,SSerialCommandSel,SSerialDataSel,
+		                                SSerialRAMSel0,SSerialRAMSel1,SSerialRAMSel2,SSerialRAMSel3)
+		begin
+			if Aint(AddrWidth-1 downto 8) = SSerialCommandAddr then
+				SSerialCommandSel <= '1';
+			else
+				SSerialCommandSel <= '0';
+			end if;
+			if Aint(AddrWidth-1 downto 8) = SSerialDataAddr then
+				SSerialDataSel <= '1';
+			else
+				SSerialDataSel <= '0';
+			end if;
+			if Aint(AddrWidth-1 downto 8) = SSerialRAMAddr0 then
+				SSerialRAMSel0 <= '1';
+			else
+				SSerialRAMSel0 <= '0';
+			end if;
+			if Aint(AddrWidth-1 downto 8) = SSerialRAMAddr1 then
+				SSerialRAMSel1 <= '1';
+			else
+				SSerialRAMSel1 <= '0';
+			end if;
+			if Aint(AddrWidth-1 downto 8) = SSerialRAMAddr2 then
+				SSerialRAMSel2 <= '1';
+			else
+				SSerialRAMSel2 <= '0';
+			end if;
+			if Aint(AddrWidth-1 downto 8) = SSerialRAMAddr3 then
+				SSerialRAMSel3 <= '1';
+			else
+				SSerialRAMSel3 <= '0';
+			end if;
+			LoadSSerialCommand <= OneOfNDecode(SSerials,SSerialCommandSel,writestb,Aint(7 downto 6));
+			ReadSSerialCommand <= OneOfNDecode(SSerials,SSerialCommandSel,Readstb,Aint(7 downto 6));
+			LoadSSerialData <= OneOfNDecode(SSerials,SSerialDataSel,writestb,Aint(7 downto 6));
+			ReadSSerialData <= OneOfNDecode(SSerials,SSerialDataSel,Readstb,Aint(7 downto 6));
+			LoadSSerialRam0 <= OneOfNDecode(SSerials,SSerialRAMSel0,writestb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max, this implies 4 max sserials
+			ReadSSerialRam0 <= OneOfNDecode(SSerials,SSerialRAMSel0,Readstb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max, this implies 4 max sserials
+			LoadSSerialRam1 <= OneOfNDecode(SSerials,SSerialRAMSel1,writestb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max, this implies 4 max sserials
+			ReadSSerialRam1 <= OneOfNDecode(SSerials,SSerialRAMSel1,Readstb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max
+			LoadSSerialRam2 <= OneOfNDecode(SSerials,SSerialRAMSel2,writestb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max
+			ReadSSerialRam2 <= OneOfNDecode(SSerials,SSerialRAMSel2,Readstb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max
+			LoadSSerialRam3 <= OneOfNDecode(SSerials,SSerialRAMSel3,writestb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max
+			ReadSSerialRam3 <= OneOfNDecode(SSerials,SSerialRAMSel3,Readstb,Aint(7 downto 6)); 	-- 16 addresses per SSerial RAM max
+        report "Max UARTS per sserial " & integer'image(MaxUARTSPerSSerial);
+        report "UARTS per sserial 0 " &  integer 'image(UARTSPerSSerial(0));
+        report "UARTS per sserial 1 " &  integer 'image(UARTSPerSSerial(1));
+        report "UARTS per sserial 2 " &  integer 'image(UARTSPerSSerial(2));
+        report "UARTS per sserial 3 " &  integer 'image(UARTSPerSSerial(3));
+
+
+		end process SSerialDecodeProcess;
+
+		DoSSerialPins: process(SSerialTX, SSerialTXEn, SSerialTestBits, IOBitsCorein)
+		begin
+			for i in 0 to IOWidth -1 loop				-- loop through all the external I/O pins
+				if ThePinDesc(i)(15 downto 8) = SSerialTag then 	-- this hideous masking of pinnumbers/vs pintype is why they should be separate bytes, maybe IDROM type 4...
+					if (ThePinDesc(i)(7 downto 0) and x"F0") = x"80" then 	-- txouts match 8X
+						CoreDataOut(i) <=   SSerialTX(conv_integer(ThePinDesc(i)(23 downto 16)))(conv_integer(ThePinDesc(i)(3 downto 0))-1);	-- 16 max ports
+					end if;
+					if (ThePinDesc(i)(7 downto 0) and x"F0") = x"90" then 	-- txens match 9X
+						CoreDataOut(i) <= not SSerialTXEn(conv_integer(ThePinDesc(i)(23 downto 16)))(conv_integer(ThePinDesc(i)(3 downto 0))-1); 	-- 16 max ports
+					end if;
+					if (ThePinDesc(i)(7 downto 0) and x"F0") = x"00" then 	-- rxins match 0X
+						SSerialRX(conv_integer(ThePinDesc(i)(23 downto 16)))(conv_integer(ThePinDesc(i)(3 downto 0))-1) <= IOBitsCorein(i);		-- 16 max ports
+					end if;
+					if ThePinDesc(i)(7 downto 0) = SSerialTestPin then
+						CoreDataOut(i) <= SSerialTestBits(i);
+					end if;
+				end if;
+			end loop;
+		end process;
+    end generate makesserialmod;
+
+end dataflow;

--- a/README.MD
+++ b/README.MD
@@ -37,6 +37,13 @@ cd /work/HW/firmware-tag
 make TOPDIR=/work py-proto
 ````
 
+### See bitfile configs available in a project
+````
+# From the Docker Quartus build image command line, run:
+cd /work/HW/QuartusProjects/<project>
+./build.sh ?
+````
+
 ### Build the desired FPGA bit file
 ````
 # From the Docker Quartus build image command line, run:


### PR DESCRIPTION
DExx: Adds SSerial support and bitfile for the new [ST-DC1 daughtercard](https://github.com/ShadeTechnik/socfpga-developement-OSHW/tree/master/DE10-Nano/ST-DC1%20daughtercard)
Plus an update to the readme
And some config enhancements 
(mux enable/disable)
(select pin numbers for capsense in SV config file)